### PR TITLE
rtk: fleet install + chezmoi-managed config with dialed-back hook filters

### DIFF
--- a/.chezmoiignore
+++ b/.chezmoiignore
@@ -32,3 +32,7 @@ iterm2-preferences
 # (.chezmoiignore is itself templated; stat is re-evaluated every apply, so this
 # self-corrects after `brew bundle` installs the app, or if it's removed).
 {{ if or (ne .chezmoi.os "darwin") (not (stat "/Applications/Sublime Text.app")) }}bin/subl{{ end }}
+
+# rtk config: one shared template, two OS-specific targets. rtk hard-wires
+# ~/Library/Application Support on darwin (ignores XDG) and ~/.config elsewhere.
+{{ if ne .chezmoi.os "darwin" }}Library{{ else }}.config/rtk{{ end }}

--- a/.chezmoitemplates/rtk-config.toml
+++ b/.chezmoitemplates/rtk-config.toml
@@ -1,0 +1,87 @@
+[tracking]
+enabled = true
+history_days = 90
+
+[display]
+colors = true
+emoji = true
+max_width = 120
+
+[filters]
+ignore_dirs = [
+    ".git",
+    "node_modules",
+    "target",
+    "__pycache__",
+    ".venv",
+    "vendor",
+]
+ignore_files = [
+    "*.lock",
+    "*.min.js",
+    "*.min.css",
+]
+
+[tee]
+enabled = true
+mode = "failures"
+max_files = 20
+max_file_size = 1048576
+
+[telemetry]
+enabled = false
+consent_given = false
+consent_date = "2026-06-21T06:05:58.603291+00:00"
+
+[hooks]
+exclude_commands = [
+    "rg",  # rtk grep backend is BSD grep on macOS; rg flags break silently (exit 0)
+    "grep",  # 254/287 parse failures; 6.1K lifetime savings vs silent zero-match risk
+    "curl",  # 2 tokens saved on 138K input; schema-compaction risks mangling API responses
+    "diff",  # 28 parse failures vs 8 filtered runs; condensing strips hunk context
+]
+# git restricted to commit/fetch: compact filters strip output the model needs (e.g. stash SHA)
+transparent_prefixes = [
+    "git stash",
+    "git status",
+    "git log",
+    "git diff",
+    "git add",
+    "git push",
+    "git pull",
+    "git branch",
+    "git show",
+    "git worktree",
+    "git checkout",
+    "git switch",
+    "git restore",
+    "git reset",
+    "git merge",
+    "git rebase",
+    "git remote",
+    "git rev-parse",
+    "git tag",
+    "git blame",
+    "git ls-files",
+    "git ls-remote",
+    "git reflog",
+    "git cherry-pick",
+    "git describe",
+    "git config",
+    "git check-attr",
+    "git submodule",
+    "git clean",
+    "git rm",
+    "git mv",
+    "git init",
+    "git clone",
+    "git apply",
+    "git bisect",
+]
+
+[limits]
+grep_max_results = 200
+grep_max_per_file = 25
+status_max_files = 15
+status_max_untracked = 10
+passthrough_max_chars = 2000

--- a/2026_REFRESH.md
+++ b/2026_REFRESH.md
@@ -61,6 +61,7 @@ Old bash-specific files removed (git history preserved).
 | ripgrep (rg) | Better grep |
 | fzf | Fuzzy finder |
 | git-delta | Better git diff |
+| rtk | Token-optimizing CLI proxy for Claude Code (one-time `rtk init -g`, see below) |
 
 ### Brewfile Pared Down
 
@@ -113,6 +114,20 @@ cd ~/.dotfiles
 ./install.sh
 exec zsh
 ```
+
+### Post-install: wire rtk into Claude Code (one-time, per machine)
+
+`rtk` (the token-optimizing Claude Code proxy) installs fleet-wide via the mise
+baseline, but its Claude integration writes to `~/.claude/` — which chezmoi does
+not manage — so it needs a single manual step after install:
+
+```bash
+rtk init -g          # hook + RTK.md + @RTK.md in ~/.claude/CLAUDE.md + settings.json
+rtk init --show      # verify: all rows [ok]
+```
+
+Idempotent — safe to re-run. Skips automation in the dotfiles repo on purpose so
+chezmoi never fights rtk over `~/.claude/CLAUDE.md` and `settings.json`.
 
 ## Verification
 

--- a/2026_REFRESH.md
+++ b/2026_REFRESH.md
@@ -129,6 +129,14 @@ rtk init --show      # verify: all rows [ok]
 Idempotent — safe to re-run. Skips automation in the dotfiles repo on purpose so
 chezmoi never fights rtk over `~/.claude/CLAUDE.md` and `settings.json`.
 
+rtk's own config *is* chezmoi-managed (`.chezmoitemplates/rtk-config.toml`, one
+template → `~/.config/rtk/` on linux, `~/Library/Application Support/rtk/` on
+darwin). It dials the hook back to where filtering measurably pays off: `rg`,
+`grep`, `curl`, `diff` excluded (silent-failure risk or ~zero savings) and git
+restricted to `commit`/`fetch` via `transparent_prefixes` (compact filters
+stripped output the model needed, e.g. `git stash` SHAs). Verify a rewrite
+decision anytime with `rtk hook check "<cmd>"`.
+
 ## Verification
 
 ```bash

--- a/dot_config/mise/conf.d/fresh.toml
+++ b/dot_config/mise/conf.d/fresh.toml
@@ -45,6 +45,7 @@ starship = "latest"
 # AI coding agents
 codex    = "latest"  # openai/codex
 opencode = "latest"  # anomalyco/opencode
+rtk      = "latest"  # aqua:rtk-ai/rtk — token-optimizing CLI proxy for Claude Code.
 
 # Dotfiles management — must be in the committed baseline so a fresh machine's
 # install.sh (mise install -> chezmoi init) can bootstrap. (Previously chezmoi

--- a/dot_config/rtk/config.toml.tmpl
+++ b/dot_config/rtk/config.toml.tmpl
@@ -1,0 +1,1 @@
+{{- template "rtk-config.toml" . -}}

--- a/private_Library/private_Application Support/rtk/config.toml.tmpl
+++ b/private_Library/private_Application Support/rtk/config.toml.tmpl
@@ -1,0 +1,1 @@
+{{- template "rtk-config.toml" . -}}


### PR DESCRIPTION
## What

Two commits making rtk consistent across the fleet:

1. **8abb636** (pre-existing on this branch): rtk installs via the committed mise baseline; one-time `rtk init -g` documented in 2026_REFRESH.md.
2. **27333d0**: rtk's config is now chezmoi-managed — one shared template (`.chezmoitemplates/rtk-config.toml`) rendered to `~/.config/rtk/config.toml` on linux and `~/Library/Application Support/rtk/config.toml` on darwin (rtk hard-wires the Library path and ignores XDG on macOS — verified empirically). The unused path is suppressed per-OS in `.chezmoiignore`. Both entries are `.tmpl` so symlink-mode chezmoi writes real files; sandboxed rtk invocations must be able to read the config (same ELOOP lesson as `~/.gitattributes`).

## Why the dialed-back filters

Analysis of rtk's history DB (1,498 commands) + Claude session transcripts:

- **66% of rtk calls saved zero tokens**; savings concentrate in read/ls/ps/vitest/gh/git-commit (~665K of 702K lifetime).
- `rtk grep` backends to **BSD grep** on macOS (even with ripgrep on PATH) and swallows its usage errors with **exit 0** → silent empty results; caused a real derailment (rg `--glob` in a dep-upgrade session). grep was also 254/287 of all hook parse failures. Lifetime savings: 6.1K.
- `rtk curl`: 2 tokens saved on 138K input.
- `rtk diff`: failed to parse 28 of 36 calls; condensing strips hunk context.
- `rtk git` compact filters stripped needed output (e.g. `git stash` SHA → extra rev-parse round-trip), so git is restricted to `commit`/`fetch` (88%/66% avg savings) via `transparent_prefixes`.

Verify any rewrite decision with `rtk hook check "<cmd>"`.

## Verification

- `chezmoi diff --source <worktree>` against the live darwin config: **empty** (byte-identical render, apply is a no-op on this machine).
- `chezmoi managed`: Library chain managed with matching perms (no chmod churn); `.config/rtk` correctly ignored on darwin.
- Hook matrix via `rtk hook check`: rg/grep/curl/diff + non-commit/fetch git pass through; commit/fetch/ls/gh/ps/vitest still rewrite.