### PR TITLE
fix(mise): pin codex to aqua backend to silence npm bin-path warning

### DIFF
--- a/dot_config/mise/conf.d/fresh.toml
+++ b/dot_config/mise/conf.d/fresh.toml
@@ -45,7 +45,7 @@ starship = "latest"
 "aqua:iffse/pay-respects" = "latest"
 
 # AI coding agents
-"aqua:openai/codex" = "latest"  # native binary; bare `codex` picks the npm backend, which warns on bin-path listing (no aqua-registry for @openai/codex)
+"aqua:openai/codex" = "latest"
 opencode = "latest"  # anomalyco/opencode
 
 # Dotfiles management — must be in the committed baseline so a fresh machine's

--- a/dot_config/mise/conf.d/fresh.toml
+++ b/dot_config/mise/conf.d/fresh.toml
@@ -45,7 +45,7 @@ starship = "latest"
 "aqua:iffse/pay-respects" = "latest"
 
 # AI coding agents
-codex    = "latest"  # openai/codex
+"aqua:openai/codex" = "latest"  # native binary; bare `codex` picks the npm backend, which warns on bin-path listing (no aqua-registry for @openai/codex)
 opencode = "latest"  # anomalyco/opencode
 
 # Dotfiles management — must be in the committed baseline so a fresh machine's


### PR DESCRIPTION
## Problem

mise prints this WARN (twice, once per bin-path listing pass) on reshim / shell PATH activation:

```
mise WARN  Error listing bin paths for npm:@openai/codex@0.133.0: registry not available: no aqua-registry found for @openai/codex
```

Bare `codex = "latest"` resolves to the **npm** backend (`npm:@openai/codex`), and mise's bin-path listing for npm tools incorrectly consults the aqua-registry, which has no `@openai/codex` entry — hence the warning.

## Fix

Pin the **aqua** backend explicitly: `"aqua:openai/codex" = "latest"`.

Verified in an isolated mise config: aqua installs the native binary (0.144.1) and `mise reshim` produces **no warning**. Also tracks newer releases than the npm 0.133.0.

## Rollout note

`~/.config/mise/conf.d/fresh.toml` is a live symlink into the checkout, so after merge run `git pull` (or `chezmoi apply`) in `~/.dotfiles` and `mise install` to swap codex from npm 0.133.0 to aqua 0.144.x.