### PR TITLE
fix(git): manage gh credential helper in template via mise exec

### DIFF
--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -141,8 +141,10 @@
 # {{ "}}}" }}
 
 # GitHub HTTPS auth via gh, resolved through mise (version- and PATH-agnostic).
-# Gated on gh being installed so this is a no-op on headless machines without it.
-{{ if lookPath "gh" -}}
+# Gated on gh being resolvable through mise (not just on PATH), so this is a
+# no-op on machines lacking mise or the gh tool, and correct even when mise
+# isn't shell-activated during `chezmoi apply`.
+{{ if output "sh" "-c" "mise which gh 2>/dev/null || true" | trim -}}
 [credential "https://github.com"]
 	helper =
 	helper = !mise exec -- gh auth git-credential

--- a/dot_gitconfig.tmpl
+++ b/dot_gitconfig.tmpl
@@ -139,3 +139,14 @@
   # initial empty commit
   empty = "!git commit -am\"[empty] Initial commit\" --allow-empty"
 # {{ "}}}" }}
+
+# GitHub HTTPS auth via gh, resolved through mise (version- and PATH-agnostic).
+# Gated on gh being installed so this is a no-op on headless machines without it.
+{{ if lookPath "gh" -}}
+[credential "https://github.com"]
+	helper =
+	helper = !mise exec -- gh auth git-credential
+[credential "https://gist.github.com"]
+	helper =
+	helper = !mise exec -- gh auth git-credential
+{{ end -}}


### PR DESCRIPTION
## Triage

`chezmoi diff` showed pending **removal** of two `[credential]` blocks from `~/.gitconfig`:

```
[credential "https://github.com"]
	helper = !/Users/simloovoo/.local/share/mise/installs/gh/latest/gh_2.92.0_macOS_arm64/bin/gh auth git-credential
[credential "https://gist.github.com"]
	helper = !.../gh_2.92.0_macOS_arm64/bin/gh auth git-credential
```

Root cause: `gh auth setup-git` appended these to the **live** `~/.gitconfig`, but that file is chezmoi-managed from `dot_gitconfig.tmpl`, which had no credential handling. So every `chezmoi apply` wanted to strip them (the `MM` churn loop), and the hardcoded path was doubly fragile:

- **Version-stamped** — `gh_2.92.0_macOS_arm64` is a real subdir even under `latest/`; breaks on the next gh upgrade.
- **Machine-specific** — hardcodes home, `macOS`, `arm64`; wrong on the Linux/pi fleet.

## Fix

Bake the credential blocks into the template using `!mise exec -- gh auth git-credential`:

- **Version- & arch-agnostic** — mise resolves gh, no stamped path.
- **PATH-robust at runtime** — only needs `mise` on PATH (Homebrew guarantees it), independent of shell activation state.
- **Gated on `mise which gh`** (via `sh -c "mise which gh 2>/dev/null || true"`), not `lookPath "gh"`: lookPath checks the bare PATH and would false-negative when gh is a mise tool but mise isn't shell-activated during `chezmoi apply`. The `|| true` wrapper means a missing tool (or missing mise) yields empty and omits the block instead of aborting the apply — a clean no-op on headless machines without gh.

## Verification

- `mise exec -- gh auth git-credential get` returns valid creds (exit 0) from a neutral dir; `mise which gh` exits 0 when present, 1 (tolerated) when absent.
- `chezmoi execute-template` renders the block; diff vs. live `~/.gitconfig` shows only the helper path swap (old versioned path → `mise exec`), everything else byte-identical. Resolves the churn.