### PR TITLE
chore(git): ignore .claude/worktrees in global gitignore

### DIFF
--- a/dot_gitignore.tmpl
+++ b/dot_gitignore.tmpl
@@ -31,3 +31,6 @@ Icon
 
 .idea
 .obsidian
+
+# Claude Code worktrees
+.claude/worktrees

--- a/dot_gitignore.tmpl
+++ b/dot_gitignore.tmpl
@@ -31,6 +31,4 @@ Icon
 
 .idea
 .obsidian
-
-# Claude Code worktrees
 .claude/worktrees


### PR DESCRIPTION
Adds `.claude/worktrees` to the chezmoi-managed global gitignore (`dot_gitignore.tmpl`) so Claude Code worktrees are never tracked.