### PR TITLE
rtk: allowlist-gated hook, minimal config, no rtk init -g

### DIFF
--- a/.chezmoitemplates/rtk-config.toml
+++ b/.chezmoitemplates/rtk-config.toml
@@ -39,6 +39,20 @@ exclude_commands = [
     "grep",  # 254/287 parse failures; 6.1K lifetime savings vs silent zero-match risk
     "curl",  # 2 tokens saved on 138K input; schema-compaction risks mangling API responses
     "diff",  # 28 parse failures vs 8 filtered runs; condensing strips hunk context
+    # JS toolchain: rtk drops the package-manager wrapper and substitutes its own
+    # handler, e.g. `pnpm lint` -> `rtk lint` (runs rtk's eslint, not your script),
+    # `pnpm exec prettier` -> `rtk prettier` (resolves PATH, not node_modules/.bin),
+    # `pnpm vitest run` -> `rtk vitest` (drops `run`; watch-mode hang in a non-TTY).
+    # It also only fires on some flag shapes -- `pnpm run lint` rewrites but
+    # `pnpm --filter web run lint` does not -- so behavior is unpredictable.
+    "pnpm",  # 43 of 54 calls saved zero; all savings were `pnpm install` alone
+    "npm",  # 2 calls, 26 tokens
+    "npx",  # 32 calls, 103.7K input tokens, 58 saved (0.1%)
+    "yarn",  # no handler today; excluded so a future one can't substitute
+    "bun",  # same
+    "tsc",  # 7 calls, 0 tokens saved, wrong-binary risk outside pnpm exec
+    "eslint",  # rtk lint: 3 calls; substitutes for project lint config
+    "prettier",  # 3 calls, 11 tokens saved
 ]
 # git restricted to commit/fetch: compact filters strip output the model needs (e.g. stash SHA)
 transparent_prefixes = [

--- a/.chezmoitemplates/rtk-config.toml
+++ b/.chezmoitemplates/rtk-config.toml
@@ -1,101 +1,21 @@
+# rtk config -- deliberately minimal.
+#
+# Everything omitted here is rtk's own default (verified against a fresh
+# `rtk config --create`), so only settings carrying actual intent are pinned.
+#
+# There is no [hooks] section on purpose. rtk's exclude_commands and
+# transparent_prefixes are denylists, and the Claude Code hook now runs through
+# ~/bin/rtk-allowlist-hook, which decides whether rtk is consulted at all. Only
+# commands named in ~/.config/rtk-allowlist.toml ever reach rtk, so a denylist
+# here would be unreachable policy -- and worse, a second place to edit: allowing
+# something in the allowlist stayed silently inert while rtk still excluded it.
+# One list, one file.
+
 [tracking]
-enabled = true
+enabled = true  # powers `rtk gain`, the feedback loop for tuning the allowlist
 history_days = 90
 
-[display]
-colors = true
-emoji = true
-max_width = 120
-
-[filters]
-ignore_dirs = [
-    ".git",
-    "node_modules",
-    "target",
-    "__pycache__",
-    ".venv",
-    "vendor",
-]
-ignore_files = [
-    "*.lock",
-    "*.min.js",
-    "*.min.css",
-]
-
-[tee]
-enabled = true
-mode = "failures"
-max_files = 20
-max_file_size = 1048576
-
 [telemetry]
-enabled = false
+enabled = false  # pinned, not merely defaulted, so an upgrade cannot opt us in
 consent_given = false
 consent_date = "2026-06-21T06:05:58.603291+00:00"
-
-[hooks]
-exclude_commands = [
-    "rg",  # rtk grep backend is BSD grep on macOS; rg flags break silently (exit 0)
-    "grep",  # 254/287 parse failures; 6.1K lifetime savings vs silent zero-match risk
-    "curl",  # 2 tokens saved on 138K input; schema-compaction risks mangling API responses
-    "diff",  # 28 parse failures vs 8 filtered runs; condensing strips hunk context
-    # JS toolchain: rtk drops the package-manager wrapper and substitutes its own
-    # handler, e.g. `pnpm lint` -> `rtk lint` (runs rtk's eslint, not your script),
-    # `pnpm exec prettier` -> `rtk prettier` (resolves PATH, not node_modules/.bin),
-    # `pnpm vitest run` -> `rtk vitest` (drops `run`; watch-mode hang in a non-TTY).
-    # It also only fires on some flag shapes -- `pnpm run lint` rewrites but
-    # `pnpm --filter web run lint` does not -- so behavior is unpredictable.
-    "pnpm",  # 43 of 54 calls saved zero; all savings were `pnpm install` alone
-    "npm",  # 2 calls, 26 tokens
-    "npx",  # 32 calls, 103.7K input tokens, 58 saved (0.1%)
-    "yarn",  # no handler today; excluded so a future one can't substitute
-    "bun",  # same
-    "tsc",  # 7 calls, 0 tokens saved, wrong-binary risk outside pnpm exec
-    "eslint",  # rtk lint: 3 calls; substitutes for project lint config
-    "prettier",  # 3 calls, 11 tokens saved
-]
-# git restricted to commit/fetch: compact filters strip output the model needs (e.g. stash SHA)
-transparent_prefixes = [
-    "git stash",
-    "git status",
-    "git log",
-    "git diff",
-    "git add",
-    "git push",
-    "git pull",
-    "git branch",
-    "git show",
-    "git worktree",
-    "git checkout",
-    "git switch",
-    "git restore",
-    "git reset",
-    "git merge",
-    "git rebase",
-    "git remote",
-    "git rev-parse",
-    "git tag",
-    "git blame",
-    "git ls-files",
-    "git ls-remote",
-    "git reflog",
-    "git cherry-pick",
-    "git describe",
-    "git config",
-    "git check-attr",
-    "git submodule",
-    "git clean",
-    "git rm",
-    "git mv",
-    "git init",
-    "git clone",
-    "git apply",
-    "git bisect",
-]
-
-[limits]
-grep_max_results = 200
-grep_max_per_file = 25
-status_max_files = 15
-status_max_untracked = 10
-passthrough_max_chars = 2000

--- a/2026_REFRESH.md
+++ b/2026_REFRESH.md
@@ -134,7 +134,12 @@ template → `~/.config/rtk/` on linux, `~/Library/Application Support/rtk/` on
 darwin). It dials the hook back to where filtering measurably pays off: `rg`,
 `grep`, `curl`, `diff` excluded (silent-failure risk or ~zero savings) and git
 restricted to `commit`/`fetch` via `transparent_prefixes` (compact filters
-stripped output the model needed, e.g. `git stash` SHAs). Verify a rewrite
+stripped output the model needed, e.g. `git stash` SHAs). The whole JS toolchain
+(`pnpm`, `npm`, `npx`, `yarn`, `bun`, `tsc`, `eslint`, `prettier`) is excluded too:
+rtk drops the package-manager wrapper and substitutes its own handler, so
+`pnpm lint` ran rtk's eslint instead of the project's `lint` script and
+`pnpm exec prettier` resolved `prettier` off `PATH` instead of `node_modules/.bin`.
+Across 90 days those commands saved 0.1% of their input tokens. Verify a rewrite
 decision anytime with `rtk hook check "<cmd>"`.
 
 ## Verification

--- a/2026_REFRESH.md
+++ b/2026_REFRESH.md
@@ -130,8 +130,13 @@ them on the next apply.
 
 rtk has no opt-in mode — `exclude_commands` and `transparent_prefixes` are both
 denylists, so every handler it ships is armed by default and each release re-arms
-the surface. Of the 33 handlers it hooks, 21 had been invoked *zero* times in 90
-days while still able to rewrite.
+the surface. rtk 0.43.0 rewrites 46 distinct commands, 25 of which had been
+invoked *zero* times in 90 days while still able to rewrite.
+
+That is not a static number, which is the whole argument: 0.43.0 added `oc` and
+`pulumi` (43 → 46) with no action on our side. Under a denylist both would have
+been live the moment mise pulled the release; under the allowlist both were
+denied by default, verified rather than assumed.
 
 They are not harmless: rtk *substitutes* rather than filters, dropping the wrapper
 and any argument it does not recognize. `pnpm lint` ran rtk's eslint instead of

--- a/2026_REFRESH.md
+++ b/2026_REFRESH.md
@@ -139,8 +139,42 @@ stripped output the model needed, e.g. `git stash` SHAs). The whole JS toolchain
 rtk drops the package-manager wrapper and substitutes its own handler, so
 `pnpm lint` ran rtk's eslint instead of the project's `lint` script and
 `pnpm exec prettier` resolved `prettier` off `PATH` instead of `node_modules/.bin`.
-Across 90 days those commands saved 0.1% of their input tokens. Verify a rewrite
-decision anytime with `rtk hook check "<cmd>"`.
+Across 90 days those commands saved 0.1% of their input tokens.
+
+Denylisting is a losing game though, because rtk has no opt-in mode — every
+handler it ships is armed by default and each release re-arms the surface. Of
+the 33 handlers it hooks, 21 had been invoked *zero* times in 90 days while
+still being able to rewrite. So the Bash `PreToolUse` hook points at
+`~/bin/rtk-allowlist-hook` instead of `rtk hook claude` directly:
+
+```
+Claude Bash call -> rtk-allowlist-hook -> (allowed?) -> rtk hook claude
+                                       -> (else)    -> no rewrite
+```
+
+rtk stays the rewrite engine; the wrapper only decides *whether it is consulted*.
+The allowlist is `~/.config/rtk-allowlist.toml` (chezmoi-managed), holding the
+~11 commands with measured savings plus `git commit`/`git fetch`. Everything
+else passes through. It also refuses to touch compound commands (pipes, `&&`,
+redirection), since rtk parses only the leading command. It fails open on every
+error path — bad JSON, missing rtk, timeout — so a broken hook can never block a
+command, and falls back to built-in defaults if the TOML is missing or malformed
+rather than reverting to rtk's wide-open behavior.
+
+Setting `commands = []` in that TOML disables rewriting entirely while leaving
+`rtk gain` and manual `rtk <cmd>` usage intact.
+
+Verify the engine's view with `rtk hook check "<cmd>"`, and the *actual* decision
+(which is what matters) with:
+
+```bash
+echo '{"tool_name":"Bash","tool_input":{"command":"ls -la"}}' | ~/bin/rtk-allowlist-hook
+# prints the rewrite, or nothing at all if the command is not allowlisted
+```
+
+Caveat: `~/.claude/settings.json` is owned by `rtk init -g`, not chezmoi, so
+re-running it points the Bash hook back at `rtk hook claude`. Re-apply the
+wrapper afterwards.
 
 ## Verification
 

--- a/2026_REFRESH.md
+++ b/2026_REFRESH.md
@@ -61,7 +61,7 @@ Old bash-specific files removed (git history preserved).
 | ripgrep (rg) | Better grep |
 | fzf | Fuzzy finder |
 | git-delta | Better git diff |
-| rtk | Token-optimizing CLI proxy for Claude Code (one-time `rtk init -g`, see below) |
+| rtk | Token-optimizing CLI proxy for Claude Code (allowlist-gated, see below) |
 
 ### Brewfile Pared Down
 
@@ -115,66 +115,74 @@ cd ~/.dotfiles
 exec zsh
 ```
 
-### Post-install: wire rtk into Claude Code (one-time, per machine)
+### rtk in Claude Code (no manual step)
 
-`rtk` (the token-optimizing Claude Code proxy) installs fleet-wide via the mise
-baseline, but its Claude integration writes to `~/.claude/` — which chezmoi does
-not manage — so it needs a single manual step after install:
+`rtk` (the token-optimizing proxy) installs fleet-wide via the mise baseline, and
+its Claude Code wiring is handled by `run_after_20-claude-rtk-hook.sh` on every
+`chezmoi apply`. There is nothing to run by hand.
 
-```bash
-rtk init -g          # hook + RTK.md + @RTK.md in ~/.claude/CLAUDE.md + settings.json
-rtk init --show      # verify: all rows [ok]
-```
+**Do not run `rtk init -g`.** It points the Bash `PreToolUse` hook straight at
+`rtk hook claude` and overwrites `~/.claude/RTK.md` with guidance claiming every
+command is rewritten. Both are wrong for this setup, and the run-script undoes
+them on the next apply.
 
-Idempotent — safe to re-run. Skips automation in the dotfiles repo on purpose so
-chezmoi never fights rtk over `~/.claude/CLAUDE.md` and `settings.json`.
+#### Why it is an allowlist
 
-rtk's own config *is* chezmoi-managed (`.chezmoitemplates/rtk-config.toml`, one
-template → `~/.config/rtk/` on linux, `~/Library/Application Support/rtk/` on
-darwin). It dials the hook back to where filtering measurably pays off: `rg`,
-`grep`, `curl`, `diff` excluded (silent-failure risk or ~zero savings) and git
-restricted to `commit`/`fetch` via `transparent_prefixes` (compact filters
-stripped output the model needed, e.g. `git stash` SHAs). The whole JS toolchain
-(`pnpm`, `npm`, `npx`, `yarn`, `bun`, `tsc`, `eslint`, `prettier`) is excluded too:
-rtk drops the package-manager wrapper and substitutes its own handler, so
-`pnpm lint` ran rtk's eslint instead of the project's `lint` script and
-`pnpm exec prettier` resolved `prettier` off `PATH` instead of `node_modules/.bin`.
-Across 90 days those commands saved 0.1% of their input tokens.
+rtk has no opt-in mode — `exclude_commands` and `transparent_prefixes` are both
+denylists, so every handler it ships is armed by default and each release re-arms
+the surface. Of the 33 handlers it hooks, 21 had been invoked *zero* times in 90
+days while still able to rewrite.
 
-Denylisting is a losing game though, because rtk has no opt-in mode — every
-handler it ships is armed by default and each release re-arms the surface. Of
-the 33 handlers it hooks, 21 had been invoked *zero* times in 90 days while
-still being able to rewrite. So the Bash `PreToolUse` hook points at
-`~/bin/rtk-allowlist-hook` instead of `rtk hook claude` directly:
+They are not harmless: rtk *substitutes* rather than filters, dropping the wrapper
+and any argument it does not recognize. `pnpm lint` ran rtk's eslint instead of
+the project's `lint` script, `pnpm exec prettier` resolved `prettier` off `PATH`
+instead of `node_modules/.bin`, and `next build` dropped `build` outright. So the
+hook points at a wrapper instead:
 
 ```
-Claude Bash call -> rtk-allowlist-hook -> (allowed?) -> rtk hook claude
-                                       -> (else)    -> no rewrite
+Claude Bash call -> rtk-allowlist-hook -> allowed? -> rtk hook claude -> rewrite
+                                       -> else    -> no output ------> unchanged
 ```
 
 rtk stays the rewrite engine; the wrapper only decides *whether it is consulted*.
-The allowlist is `~/.config/rtk-allowlist.toml` (chezmoi-managed), holding the
-~11 commands with measured savings plus `git commit`/`git fetch`. Everything
-else passes through. It also refuses to touch compound commands (pipes, `&&`,
-redirection), since rtk parses only the leading command. It fails open on every
-error path — bad JSON, missing rtk, timeout — so a broken hook can never block a
-command, and falls back to built-in defaults if the TOML is missing or malformed
-rather than reverting to rtk's wide-open behavior.
 
-Setting `commands = []` in that TOML disables rewriting entirely while leaving
-`rtk gain` and manual `rtk <cmd>` usage intact.
+#### The pieces
 
-Verify the engine's view with `rtk hook check "<cmd>"`, and the *actual* decision
-(which is what matters) with:
+| file | role |
+|---|---|
+| `~/.config/rtk-allowlist.toml` | the allowlist — the only file to edit |
+| `~/bin/rtk-allowlist-hook` | the gate; relays allowed commands to rtk |
+| `~/.claude/RTK.md` | in-session guidance, kept honest about what is rewritten |
+| rtk's own config | deliberately minimal — no `[hooks]` section at all |
+
+The allowlist holds the ~11 commands with measured savings plus `git commit` and
+`git fetch`, which is 99.55% of lifetime savings (4.66M of 4.68M tokens).
+Compound commands (pipes, `&&`, redirection) are never rewritten, since rtk parses
+only the leading command. The gate fails open on every error path — bad JSON,
+missing rtk, timeout — so it can never block a command, and falls back to built-in
+defaults if the TOML is missing or malformed rather than reverting to rtk's
+wide-open behavior.
+
+rtk's own config pins only `[tracking]` and `[telemetry]`; everything else was
+byte-for-byte its default. It carries no denylists on purpose — with the gate in
+front they would be unreachable policy *and* a second place to edit, where
+allowing something in the allowlist stayed silently inert because rtk still
+excluded it. One list, one file.
+
+Setting `commands = []` disables rewriting entirely while leaving `rtk gain` and
+manual `rtk <cmd>` usage intact.
+
+#### Verifying
 
 ```bash
+# the actual decision (what matters):
 echo '{"tool_name":"Bash","tool_input":{"command":"ls -la"}}' | ~/bin/rtk-allowlist-hook
-# prints the rewrite, or nothing at all if the command is not allowlisted
+# prints the rewrite, or nothing at all when the command is not allowlisted
 ```
 
-Caveat: `~/.claude/settings.json` is owned by `rtk init -g`, not chezmoi, so
-re-running it points the Bash hook back at `rtk hook claude`. Re-apply the
-wrapper afterwards.
+`rtk hook check "<cmd>"` shows rtk's *engine* view, which ignores the allowlist —
+it reports rewrites for commands the hook actually leaves alone. That gap is
+expected, not a bug.
 
 ## Verification
 

--- a/dot_claude/private_RTK.md.tmpl
+++ b/dot_claude/private_RTK.md.tmpl
@@ -1,0 +1,56 @@
+# rtk (Rust Token Killer)
+
+Token-optimizing CLI proxy. A `PreToolUse` hook rewrites a **small allowlist** of
+Bash commands to their `rtk` equivalent. Do not invoke `rtk <cmd>` by hand for
+these — the hook already does it, and typing it yourself just adds tokens.
+
+## What is rewritten
+
+Only these, and only as the head of a **single simple command**:
+
+`cat` `head` `tail` `ls` `gh` `find` `wc` `du` `ps` `vitest` `cargo`,
+plus `git commit` and `git fetch`.
+
+Everything else runs untouched — including `git status`, `git diff`, `git stash`,
+`rg`, `grep`, `curl`, `diff`, and the whole JS toolchain (`pnpm`, `npm`, `npx`,
+`yarn`, `tsc`, `eslint`, `prettier`). Anything with a pipe, `&&`, `;`, or a
+redirect is never rewritten, even if its first word is on the list.
+
+Write commands normally. The hook handles the rest.
+
+## Why the list is short
+
+rtk's handlers *substitute* rather than filter — they drop the wrapper and any
+argument they don't recognize (`pnpm lint` ran rtk's eslint instead of the
+project's script; `next build` dropped `build`). Commands are on the list only
+where they measurably saved tokens without changing behavior.
+
+To change what is rewritten, edit `~/.config/rtk-allowlist.toml` — not this file,
+and not rtk's own config.
+
+## Meta commands (run these directly)
+
+```bash
+rtk gain              # token savings analytics
+rtk gain --history    # per-command history with savings
+rtk proxy <cmd>       # run a command through rtk without filtering (debugging)
+```
+
+Check what the hook would actually do with a command:
+
+```bash
+echo '{"tool_name":"Bash","tool_input":{"command":"ls -la"}}' | ~/bin/rtk-allowlist-hook
+# prints the rewrite, or nothing at all when the command is not allowlisted
+```
+
+`rtk hook check "<cmd>"` shows rtk's *engine* view, which ignores the allowlist —
+it will report rewrites for commands the hook actually leaves alone.
+
+## Do not run `rtk init -g`
+
+It overwrites this file and repoints the Bash hook straight at `rtk hook claude`,
+re-arming every handler rtk ships. The wiring is managed by chezmoi instead;
+`chezmoi apply` re-asserts it.
+
+⚠️ Name collision: if `rtk gain` fails, you may have reachingforthejack/rtk
+(Rust Type Kit) installed instead of the token proxy.

--- a/dot_config/rtk-allowlist.toml.tmpl
+++ b/dot_config/rtk-allowlist.toml.tmpl
@@ -1,0 +1,66 @@
+# Allowlist for ~/bin/rtk-allowlist-hook (Claude Code PreToolUse, Bash).
+#
+# rtk only ships denylists, so every handler it has is armed by default and each
+# release re-arms the surface. This file inverts that: a command is rewritten
+# only if it is named here. Everything else passes through untouched.
+#
+# Savings figures are from `rtk gain` over 90 days. Before adding an entry, check
+# it actually earns:  rtk gain --history | grep <cmd>
+# Check what a change does:  rtk hook check "<cmd>"   (engine view, ignores this file)
+# Check the real decision:
+#   echo '{"tool_name":"Bash","tool_input":{"command":"<cmd>"}}' | ~/bin/rtk-allowlist-hook
+# Empty output means no rewrite.
+#
+# Two layers have to agree. This file decides whether rtk is consulted at all;
+# rtk's own config still gets the final say. So adding something here that rtk
+# lists in `exclude_commands` or `transparent_prefixes` still will not rewrite --
+# e.g. allowing `git push` here is inert until it also comes off rtk's
+# transparent_prefixes. Both live in this repo:
+#   .chezmoitemplates/rtk-config.toml  (rtk's own denylists)
+#   this file                          (our allowlist gate)
+#
+# Only a single simple command is ever rewritten. Anything containing a pipe,
+# &&, ||, ;, redirection, backtick, or $(...) is passed through untouched --
+# rtk parses only the leading command, so on a compound line it would rewrite
+# the head and leave the rest inconsistent.
+#
+# `commands = []` with no [subcommands] disables rewriting entirely while
+# leaving the hook wired, which is the quickest way to turn rtk off and still
+# keep `rtk gain` and manual `rtk <cmd>` usage available.
+
+# Rewritten whenever they are the head of a single simple command.
+commands = [
+    "cat",  # -> rtk read; with head/tail the largest single win, 3.0M tokens
+    "head",
+    "tail",
+    "ls",  # 593K saved, 66%
+    "gh",  # 224K saved, 61%
+    "find",  # 3.0K saved, 96%
+    "wc",  # 982 saved, 64%
+    "du",  # TOML filter, part of the 705K "other" bucket
+    "ps",  # same
+    "vitest",  # 48.9K saved, 100%; rtk passes --no-watch so dropping `run` is safe
+    "cargo",  # 5.7K saved, 98%
+]
+
+# Rewritten only for these subcommands. Global flags (`-C <path>`, `-c k=v`) are
+# skipped when locating the subcommand, so `git -C /tmp commit` still matches.
+[subcommands]
+# commit 88%, fetch 66%. Every other git subcommand loses output the model needs
+# -- `git stash` stopped printing the SHA, costing an extra rev-parse each time.
+git = ["commit", "fetch"]
+
+# Deliberately absent, and why:
+#   pnpm npm npx yarn bun tsc eslint prettier
+#     rtk substitutes its own handler and drops arguments -- `pnpm lint` ran
+#     rtk's eslint instead of the project script, `pnpm vitest run` dropped
+#     `run`. Combined lifetime savings: 0.1% of their input tokens.
+#   rg grep
+#     rtk shells out to BSD grep on macOS; rg-only flags hit a usage error it
+#     swallows with exit 0, so searches silently return nothing.
+#   curl    2 tokens saved on 138K input.
+#   diff    strips hunk context; failed to parse 28 of 36 calls.
+#   tree df wget aws psql rsync make glab docker kubectl helm terraform go
+#   dotnet next pytest mypy ruff jest playwright prisma
+#     handlers rtk arms by default that were invoked zero times in 90 days.
+#     `next build` -> `rtk next` drops `build`, the same defect class as pnpm.

--- a/dot_config/rtk-allowlist.toml.tmpl
+++ b/dot_config/rtk-allowlist.toml.tmpl
@@ -56,8 +56,12 @@ git = ["commit", "fetch"]
 #     rtk's eslint instead of the project script, `pnpm vitest run` dropped
 #     `run`. Combined lifetime savings: 0.1% of their input tokens.
 #   rg grep
-#     rtk shells out to BSD grep on macOS; rg-only flags hit a usage error it
-#     swallows with exit 0, so searches silently return nothing.
+#     On 0.42.4 rtk ran BSD grep even when rg was invoked, so rg-only flags hit a
+#     usage error it swallowed with exit 0 and searches silently returned nothing.
+#     Fixed in 0.43.0 -- `rg foo` now runs rg -- so this pair is the most defensible
+#     candidate to re-add. Still out for now: grep was 254 of 287 lifetime parse
+#     failures for 6.1K tokens saved, and Claude Code's native Grep tool covers the
+#     same ground without a hook. Re-measure with `rtk gain --history` before adding.
 #   curl    2 tokens saved on 138K input.
 #   diff    strips hunk context; failed to parse 28 of 36 calls.
 #   tree df wget aws psql rsync make glab docker kubectl helm terraform go

--- a/private_bin/executable_rtk-allowlist-hook
+++ b/private_bin/executable_rtk-allowlist-hook
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Allowlist gate in front of `rtk hook claude` (Claude Code PreToolUse, Bash).
+
+rtk only offers denylists (`exclude_commands`, `transparent_prefixes`), so every
+handler it ships is armed by default and each new release re-arms the surface.
+Its handlers *substitute* rather than filter -- they drop the wrapper and any
+argument they do not recognize:
+
+    pnpm lint          -> rtk lint     (rtk's eslint, not the project script)
+    pnpm exec prettier -> rtk prettier (PATH, not node_modules/.bin)
+    pnpm vitest run    -> rtk vitest   (drops `run`)
+    next build         -> rtk next     (drops `build`)
+
+This flips the polarity: nothing is rewritten unless it is named in ALLOW, and
+the entry has earned it in `rtk gain` history. rtk stays the rewrite engine --
+we only decide *whether* it gets consulted.
+
+Fails open everywhere. Any parse error, missing rtk, timeout, or unexpected
+exception prints nothing and exits 0, which Claude Code reads as "no rewrite".
+A hook that breaks must never break the user's command.
+"""
+
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+
+CONFIG_PATH = os.environ.get(
+    "RTK_ALLOWLIST_CONFIG",
+    os.path.expanduser("~/.config/rtk-allowlist.toml"),
+)
+
+# Used when the config is missing or unreadable, so a lost file degrades to the
+# known-good set rather than to rtk's wide-open default.
+DEFAULT_ALLOW = {
+    "cat", "head", "tail", "ls", "gh", "find", "wc", "du", "ps", "vitest", "cargo",
+}
+DEFAULT_SUBCOMMANDS = {"git": {"commit", "fetch"}}
+
+# Shell syntax that makes this more than one simple command. rtk parses only the
+# leading command, so on a pipeline or list it would rewrite the head and leave
+# the rest -- or mangle the whole string. We decline instead of guessing.
+SHELL_METACHARS = ("&&", "||", ";", "|", "`", "$(", ">", "<", "&", "\n")
+
+RTK_TIMEOUT_SECONDS = 10
+
+_ARRAY_RE = re.compile(r"^([A-Za-z0-9_-]+)\s*=\s*\[(.*?)\]", re.DOTALL | re.MULTILINE)
+_SECTION_RE = re.compile(r"^\s*\[([A-Za-z0-9_.-]+)\]\s*$", re.MULTILINE)
+_STRING_RE = re.compile(r'"([^"]*)"')
+
+
+def _parse_toml_subset(text: str) -> dict:
+    """Parse the `key = [...]` / `[section]` subset this config uses.
+
+    Only needed on Python < 3.11, which has no tomllib. Deliberately narrow: it
+    understands string arrays and one level of section, which is the whole
+    schema. Anything richer belongs in tomllib, not here.
+    """
+    # Strip comments, but not a '#' inside a quoted string.
+    lines = []
+    for line in text.splitlines():
+        out, in_string, index = [], False, 0
+        while index < len(line):
+            char = line[index]
+            if char == '"':
+                in_string = not in_string
+            elif char == "#" and not in_string:
+                break
+            out.append(char)
+            index += 1
+        lines.append("".join(out))
+    stripped = "\n".join(lines)
+
+    # Split into (section_name, body) chunks; the pre-header body is top level.
+    chunks, last_end, current = [], 0, None
+    for match in _SECTION_RE.finditer(stripped):
+        chunks.append((current, stripped[last_end:match.start()]))
+        current, last_end = match.group(1), match.end()
+    chunks.append((current, stripped[last_end:]))
+
+    result: dict = {}
+    for section, body in chunks:
+        target = result if section is None else result.setdefault(section, {})
+        if not isinstance(target, dict):
+            continue
+        for match in _ARRAY_RE.finditer(body):
+            target[match.group(1)] = _STRING_RE.findall(match.group(2))
+    return result
+
+
+def load_config(path: str = CONFIG_PATH):
+    """Return (allow_set, subcommand_map), falling back to the built-in defaults."""
+    try:
+        with open(path, "rb") as handle:
+            raw = handle.read()
+    except Exception:
+        return set(DEFAULT_ALLOW), {k: set(v) for k, v in DEFAULT_SUBCOMMANDS.items()}
+
+    data = None
+    try:
+        import tomllib  # Python 3.11+
+
+        data = tomllib.loads(raw.decode("utf-8"))
+    except ImportError:
+        try:
+            data = _parse_toml_subset(raw.decode("utf-8"))
+        except Exception:
+            data = None
+    except Exception:
+        data = None  # malformed TOML -- prefer the safe defaults over a wrong list
+
+    if not isinstance(data, dict):
+        return set(DEFAULT_ALLOW), {k: set(v) for k, v in DEFAULT_SUBCOMMANDS.items()}
+
+    commands = data.get("commands")
+    allow = (
+        {c for c in commands if isinstance(c, str) and c}
+        if isinstance(commands, list)
+        else set(DEFAULT_ALLOW)
+    )
+
+    subcommands = {}
+    raw_subcommands = data.get("subcommands")
+    if isinstance(raw_subcommands, dict):
+        for name, values in raw_subcommands.items():
+            if isinstance(values, list):
+                subcommands[name] = {v for v in values if isinstance(v, str) and v}
+
+    return allow, subcommands
+
+
+ALLOW, SUBCOMMANDS = load_config()
+
+# Global flags that consume the next token, so the subcommand scan skips past
+# their value instead of mistaking it for the subcommand.
+VALUE_FLAGS = ("-C", "-c", "--git-dir", "--work-tree", "--namespace")
+
+
+def is_allowed(command: str) -> bool:
+    """True only if `command` is a single simple command named in the allowlist."""
+    if not command or not command.strip():
+        return False
+
+    if any(tok in command for tok in SHELL_METACHARS):
+        return False
+
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        return False  # unbalanced quotes -- not ours to interpret
+
+    if not tokens:
+        return False
+
+    # Strip a leading `env`-style VAR=value prefix so `FOO=1 ls` still resolves.
+    while tokens and "=" in tokens[0] and not tokens[0].startswith("-"):
+        name = tokens[0].split("=", 1)[0]
+        if name and name.replace("_", "").isalnum():
+            tokens = tokens[1:]
+        else:
+            break
+
+    if not tokens:
+        return False
+
+    head = os.path.basename(tokens[0])
+
+    if head in SUBCOMMANDS:
+        # First non-flag token after the command is the subcommand. Value-taking
+        # global flags are skipped, so `git -C /tmp commit` resolves to `commit`
+        # rather than reading the path as the subcommand.
+        allowed = SUBCOMMANDS[head]
+        rest, index = tokens[1:], 0
+        while index < len(rest):
+            token = rest[index]
+            if not token.startswith("-"):
+                return token in allowed
+            index += 2 if token in VALUE_FLAGS else 1
+        return False  # bare `git` with no subcommand
+
+    return head in ALLOW
+
+
+def main() -> int:
+    try:
+        raw = sys.stdin.read()
+    except Exception:
+        return 0
+
+    try:
+        payload = json.loads(raw)
+    except Exception:
+        return 0
+
+    if not isinstance(payload, dict):
+        return 0
+    if payload.get("tool_name") != "Bash":
+        return 0
+
+    tool_input = payload.get("tool_input")
+    if not isinstance(tool_input, dict):
+        return 0
+
+    command = tool_input.get("command")
+    if not isinstance(command, str) or not is_allowed(command):
+        return 0  # no output == no rewrite
+
+    # Allowed: hand the untouched payload to rtk and relay its verdict verbatim.
+    try:
+        result = subprocess.run(
+            ["rtk", "hook", "claude"],
+            input=raw,
+            capture_output=True,
+            text=True,
+            timeout=RTK_TIMEOUT_SECONDS,
+        )
+    except Exception:
+        return 0  # rtk missing, not on PATH, or hung -- fall through to no rewrite
+
+    if result.returncode == 0 and result.stdout.strip():
+        sys.stdout.write(result.stdout)
+
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:
+        sys.exit(0)  # never let a hook failure block a command

--- a/run_after_20-claude-rtk-hook.sh
+++ b/run_after_20-claude-rtk-hook.sh
@@ -1,0 +1,96 @@
+#!/bin/sh
+# Wire rtk into Claude Code, selectively -- the parts of `rtk init -g` we want.
+#
+# `rtk init -g` is not used: it repoints the Bash PreToolUse hook straight at
+# `rtk hook claude`, which re-arms every handler rtk ships (33 of them, 21 never
+# invoked in 90 days), and it overwrites ~/.claude/RTK.md with guidance claiming
+# everything is rewritten. This asserts only the two bits we actually want, and
+# re-asserts them on every `chezmoi apply`, so a stray `rtk init -g` self-heals.
+#
+#   1. PreToolUse[Bash] -> ~/bin/rtk-allowlist-hook   (the allowlist gate)
+#   2. ~/.claude/CLAUDE.md includes @RTK.md           (chezmoi owns RTK.md)
+#
+# Touches only those two things. Other hooks, matchers, and CLAUDE.md content are
+# left exactly as found. No-ops silently when Claude Code or python3 is absent.
+
+set -eu
+
+CLAUDE_DIR="$HOME/.claude"
+[ -d "$CLAUDE_DIR" ] || exit 0
+command -v python3 >/dev/null 2>&1 || exit 0
+
+python3 - "$CLAUDE_DIR" <<'PY'
+import json
+import os
+import sys
+
+claude_dir = sys.argv[1]
+settings_path = os.path.join(claude_dir, "settings.json")
+memory_path = os.path.join(claude_dir, "CLAUDE.md")
+
+WRAPPER = 'if [ -x "$HOME/bin/rtk-allowlist-hook" ]; then "$HOME/bin/rtk-allowlist-hook"; fi'
+changes = []
+
+# --- 1. Bash PreToolUse hook -------------------------------------------------
+# Only rewrite an entry that is already rtk's (or already ours). A Bash hook
+# pointing at something else belongs to another tool and is left alone.
+RTK_COMMANDS = ("rtk hook claude", WRAPPER)
+
+try:
+    with open(settings_path) as handle:
+        settings = json.load(handle)
+except FileNotFoundError:
+    settings = {}
+except Exception:
+    settings = None  # unparseable: do not risk truncating the user's settings
+
+if isinstance(settings, dict):
+    hooks = settings.setdefault("hooks", {})
+    pre = hooks.setdefault("PreToolUse", [])
+
+    bash_entry = next(
+        (e for e in pre if isinstance(e, dict) and e.get("matcher") == "Bash"), None
+    )
+    if bash_entry is None:
+        pre.append({"matcher": "Bash", "hooks": [{"type": "command", "command": WRAPPER}]})
+        changes.append("added Bash PreToolUse hook")
+    else:
+        inner = bash_entry.setdefault("hooks", [])
+        existing = [h for h in inner if h.get("command") in RTK_COMMANDS]
+        if not existing:
+            inner.append({"type": "command", "command": WRAPPER})
+            changes.append("added allowlist hook alongside existing Bash hooks")
+        else:
+            for hook in existing:
+                if hook.get("command") != WRAPPER:
+                    hook["command"] = WRAPPER
+                    changes.append("repointed Bash hook from `rtk hook claude`")
+
+    if changes:
+        tmp = settings_path + ".tmp"
+        with open(tmp, "w") as handle:
+            json.dump(settings, handle, indent=2)
+            handle.write("\n")
+        os.replace(tmp, settings_path)  # atomic; never leaves a half-written file
+
+# --- 2. @RTK.md include ------------------------------------------------------
+# Append-only. CLAUDE.md is the user's own global instruction file, so it is not
+# chezmoi-managed -- we only ensure the include line is present.
+try:
+    with open(memory_path) as handle:
+        memory = handle.read()
+except FileNotFoundError:
+    memory = ""
+except Exception:
+    memory = None
+
+if memory is not None and "@RTK.md" not in memory:
+    with open(memory_path, "a") as handle:
+        if memory:
+            handle.write("\n" if memory.endswith("\n") else "\n\n")
+        handle.write("@RTK.md\n")
+    changes.append("added @RTK.md include to CLAUDE.md")
+
+for change in changes:
+    print(f"rtk: {change}")
+PY


### PR DESCRIPTION
Follow-up to #8. Flips rtk from an ever-growing denylist to explicit opt-in, then strips everything the gate made redundant.

## Why a denylist can't work

rtk has **no opt-in mode** — I checked the binary; `exclude_commands` and `transparent_prefixes` are the only hook knobs and both are denylists. (`RTK_DISABLED` exists but does *not* gate the PreToolUse path.)

So every handler is armed by default and each release re-arms the surface. Of the **33 handlers** rtk hooks, **21 were invoked zero times in 90 days** and could still rewrite.

They aren't harmless — rtk *substitutes* rather than filters, dropping the wrapper and any argument it doesn't recognize:

| you ran | rtk ran | problem |
|---|---|---|
| `pnpm lint` | `rtk lint` | rtk's eslint, **not** the project's `lint` script |
| `pnpm exec prettier -w .` | `rtk prettier -w .` | resolves off `PATH`, not `node_modules/.bin` |
| `pnpm vitest run` | `rtk vitest` | drops `run` — watch-mode hang, no TTY |
| `next build` | `rtk next` | drops `build` |

Same defect class each time, so chasing it one incident at a time doesn't converge.

## Design

```
Claude Bash call ─> rtk-allowlist-hook ─> allowed? ─> rtk hook claude ─> rewrite
                                       └─ else    ─> (no output) ─────> unchanged
```

rtk stays the rewrite engine; the wrapper only decides **whether it's consulted**.

| file | role |
|---|---|
| `~/.config/rtk-allowlist.toml` | the allowlist — the only file to edit |
| `~/bin/rtk-allowlist-hook` | the gate |
| `~/.claude/RTK.md` | in-session guidance, now accurate |
| rtk's own config | minimal — **no `[hooks]` section at all** |

The list is the ~11 commands with measured savings plus `git commit`/`git fetch` — **99.55% of lifetime savings** (4.66M of 4.68M tokens).

## Minimizing rtk's config (101 → 21 lines)

With the gate in front, rtk's denylists were unreachable policy *and* a second place to edit — allowing something in the allowlist stayed silently inert because rtk still excluded it. Everything else was byte-for-byte rtk's default (checked against a fresh `rtk config --create`), so only `[tracking]` (powers `rtk gain`) and `[telemetry]` (pinned, so an upgrade can't opt us in) remain.

## Dropping `rtk init -g`

It repoints the Bash hook at `rtk hook claude` — re-arming all 33 handlers — and overwrites `~/.claude/RTK.md`. That guidance was **already wrong and loaded into every session**, advertising `git status` → `rtk git status`, which the allowlist denies.

Replaced by `run_after_20-claude-rtk-hook.sh`, which asserts only the Bash hook and the `@RTK.md` include on every `chezmoi apply`, so a stray `rtk init -g` self-heals. It is deliberately narrow:

- other hooks, matchers, and `CLAUDE.md` content left as found
- a Bash hook belonging to another tool is appended to, not replaced
- an unparseable `settings.json` is left untouched, not truncated
- no-ops without `~/.claude` or `python3`; writes are atomic via `os.replace`

## Verification

The decisive test — after removing rtk's denylists, the gate is the *only* defense:

```
rtk engine alone would now rewrite:      but the hook returns:
  git status  -> rtk git status            git status  -> no rewrite
  pnpm lint   -> rtk lint                  pnpm lint   -> no rewrite
  rg foo      -> rtk grep foo              rg foo      -> no rewrite
  npx tsc     -> rtk tsc                   npx tsc     -> no rewrite

allowlist still works:
  cat README.md -> rtk read README.md      git commit -m x -> rtk git commit -m x
  ls -la        -> rtk ls -la              vitest run      -> rtk vitest
ALL PASS (21 cases)
```

Also covered: 9 malformed-payload fail-open cases, rtk-missing-from-PATH, both TOML parsers (`tomllib` and the <3.11 fallback) producing identical output, and 7 wiring-script scenarios (fresh machine, idempotent re-run, post-`rtk init -g` recovery, unparseable settings, foreign Bash hook, existing CLAUDE.md, missing python3).

Confirmed the run script registers as a chezmoi *script*, not a `$HOME` file, and that `~/.claude` permissions are unchanged.

## Safety properties

| property | behavior |
|---|---|
| bad JSON / missing rtk / timeout / exception | prints nothing, exits 0 → no rewrite |
| TOML missing or malformed | falls back to built-in defaults, **not** rtk's wide-open behavior |
| compound commands (`\|`, `&&`, `;`, `>`, `$()`) | never rewritten |
| `commands = []` | disables rewriting entirely; `rtk gain` still works |

Latency: ~35ms denied, ~49ms allowed.

Also fixes the `transparent_prefixes` string-match caveat from #8 — `git -C /tmp commit` now matches, since the subcommand scan skips value-taking global flags.

---

## Verified against rtk 0.43.0

Upgraded and re-probed. **The surface grew: 43 → 46 rewritten commands.**

| change in 0.43.0 | 0.42.4 | 0.43.0 |
|---|---|---|
| `oc get pods` | no rewrite | `rtk oc get pods` (**new**) |
| `pulumi up` | no rewrite | `rtk pulumi up` (**new**) |
| `uv run pytest` | no rewrite | `uv run rtk pytest` (**new**) |

Nothing was removed. Three new rewrite paths arrived with no action on our side — one of them *inside* `uv run`, the same week uv went fleet-wide (#15). Under a denylist all three would have been live the moment mise pulled the release. Under the allowlist all three were denied by default:

```
=== NEW 0.43.0 handlers must be denied ===
  ok  oc get pods        -> no rewrite
  ok  pulumi up          -> no rewrite
  ok  pulumi preview     -> no rewrite
  ok  uv sync            -> no rewrite
  ok  uv run pytest      -> no rewrite
  ok  uv run python x.py -> no rewrite
ALL PASS on rtk 0.43.0 (29 cases)
```

covering the new handlers, all prior denials, and all 11 allowlist entries.

### Counts corrected

The earlier "33 handlers, 21 never invoked" was measured while rtk's own `exclude_commands` was still filtering the probe, so it understated the surface. With the config now minimal, the honest figures are **46 rewritten, 25 never invoked in 90 days**. Docs updated.

### The rg bug is fixed upstream

0.43.0's `run the invoked engine instead of substituting rg for grep` fixes the defect that started this investigation:

```
0.42.4:  rg foo  ->  rtk grep foo     # the bug: BSD grep, exit-0 swallowed errors
0.43.0:  rg foo  ->  rtk rg foo       # runs the engine actually invoked
```

`rg`/`grep` are therefore the most defensible candidates to re-add. Left out for now — grep was 254 of 287 lifetime parse failures for 6.1K tokens saved, and Claude Code's native Grep tool covers the same ground without a hook — but the rationale comment now says this instead of citing a bug that no longer exists.

### No version pin

The baseline tracks `rtk = "latest"`, so mise picks up 0.43.0 on its own; there's no version string to bump. This branch does not touch `fresh.toml`, so #14's `node = "lts"` is unaffected.
