### PR TITLE
fix(mise): inherit projects' node versions; lts as system default

### DIFF
--- a/dot_config/mise/conf.d/fresh.toml
+++ b/dot_config/mise/conf.d/fresh.toml
@@ -3,6 +3,13 @@
 # Machine-local entry point: ~/.config/mise/config.toml (seeded once, edit freely).
 # Per-machine overrides: ~/.config/mise/config.local.toml.
 
+[settings]
+# Read node's version from a project's .nvmrc / .node-version instead of pinning
+# it below. mise reads mise.toml / .tool-versions natively, but these "idiomatic"
+# per-language files are opt-in and an empty list means off, not unrestricted.
+# Same setting lit-ui-router sets in its own .config/mise/config.toml.
+idiomatic_version_file_enable_tools = ["node"]
+
 [settings.github]
 # Pull a GitHub token on demand from gh CLI to avoid API rate limits
 # when mise fetches release metadata for aqua/ubi-backed tools.

--- a/dot_config/mise/conf.d/fresh.toml
+++ b/dot_config/mise/conf.d/fresh.toml
@@ -15,7 +15,7 @@ uvx = true  # "pipx:<pkg>" installs via `uv tool`, no pipx binary needed (defaul
 # Languages
 bun  = "latest"
 go   = "latest"
-node = "22"
+node = "lts"  # system default only; projects override via .nvmrc / .node-version / mise.toml
 rust = "latest"
 
 # Python: uv owns interpreters, venvs, and `uv run` scripts. CLI tools are "pipx:<pkg>".


### PR DESCRIPTION
## What

`dot_config/mise/conf.d/fresh.toml`, two changes:

```toml
[settings]
idiomatic_version_file_enable_tools = ["node"]   # new

[tools]
node = "lts"   # was "22"
```

## Why

The baseline hard-pinned node 22, and mise's idiomatic version files were off — so `.nvmrc` / `.node-version` were ignored fleet-wide and every project got node 22 regardless of what it declared.

Both changes are needed. Unpinning alone would only have swapped *which* version was imposed; enabling idiomatic files alone would leave a stale pin as the fallback. Together: projects declare their own, and `lts` is a pure system default for scratch dirs and headless boxes.

This is the same setting lit-ui-router already sets in its own `.config/mise/config.toml`, commented *"read the node version from .nvmrc instead of pinning it here."*

## Verification

Measured in clean scratch dirs with no project config (lit-ui-router is not a valid test — it sets the setting itself, which is what initially misled me into thinking an empty list meant "unrestricted" rather than "off"):

| dir | before | after |
|---|---|---|
| bare, no declaration | 22.23.1 | 24.18.0 ← `lts` fallback |
| `.nvmrc` = v24.18.0 | 22.23.1 | 24.18.0 |
| `.node-version` = 24.18.0 | 22.23.1 | 24.18.0 |
| `.nvmrc` = 20.19.0 | 22.23.1 | 20.19.0 ← project beats global |

The last row is the discriminating one: a project pin that diverges from `lts` wins. "After" was measured with the branch's `fresh.toml` installed into an isolated `MISE_CONFIG_DIR`, so the setting is confirmed to load from the global `conf.d` file, not just from an env var. `taplo check` passes.

## Notes

- Scoped to `["node"]`, matching lit-ui-router. Python is deliberately excluded — uv reads `.python-version` itself and isn't a mise tool here.
- `lts` (currently 24.18.0) rather than `latest`: this is what you get where nothing is declared, so tracking LTS is the conservative default. Other languages stay on `latest`.
- `not_found_auto_install = true` is already set fleet-wide, so `cd` into a repo pinning a node you lack installs it on demand.
- Precedence, highest first: project `mise.toml` / `.tool-versions` / `.nvmrc` → `config.local.toml` → `config.toml` → this baseline.
- Not applied to your machine until `chezmoi apply` + `mise install`; node 22 stays on disk until `mise prune`.

## Commits

Two commits, kept separate because the second corrects the first's reasoning rather than restating it.