### PR TITLE
mise: auto-activate uv project venvs

### DIFF
--- a/2026_REFRESH.md
+++ b/2026_REFRESH.md
@@ -106,6 +106,11 @@ ripgrep, chezmoi itself, …). Shared baseline: `~/.config/mise/conf.d/fresh.tom
 (committed). Machine-local: `~/.config/mise/config.toml` (seeded once). Python is
 delegated to `uv`. `eval "$(mise activate zsh)"` runs from `.zshrc`.
 
+`settings.python.uv_venv_auto` activates a uv project's `.venv` on `cd` (creating it
+if absent), so `source .venv/bin/activate` is no longer needed. mise finds the project
+by walking up for `uv.lock` — a bare `.venv` is ignored, so run `uv sync` once in a new
+project before it takes effect.
+
 ## Installation
 
 ```bash

--- a/dot_config/mise/conf.d/fresh.toml
+++ b/dot_config/mise/conf.d/fresh.toml
@@ -19,11 +19,6 @@ credential_command = "gh auth token"
 uvx = true  # "pipx:<pkg>" installs via `uv tool`, no pipx binary needed (default when uv present)
 
 [settings.python]
-# Auto-activate a uv project's .venv on cd (exports VIRTUAL_ENV), creating it if absent —
-# no more `source .venv/bin/activate`. mise finds the project by walking up for uv.lock,
-# so a bare .venv is ignored: run `uv sync` (or `uv lock`) once before this does anything.
-# Boolean on purpose. The cookbook's `python.uv_venv_auto = "source"` string form parses
-# fine but is silently ignored on mise 2026.7.x — verified against `mise env` in a uv project.
 uv_venv_auto = true
 
 [tools]

--- a/dot_config/mise/conf.d/fresh.toml
+++ b/dot_config/mise/conf.d/fresh.toml
@@ -18,6 +18,14 @@ credential_command = "gh auth token"
 [settings.pipx]
 uvx = true  # "pipx:<pkg>" installs via `uv tool`, no pipx binary needed (default when uv present)
 
+[settings.python]
+# Auto-activate a uv project's .venv on cd (exports VIRTUAL_ENV), creating it if absent —
+# no more `source .venv/bin/activate`. mise finds the project by walking up for uv.lock,
+# so a bare .venv is ignored: run `uv sync` (or `uv lock`) once before this does anything.
+# Boolean on purpose. The cookbook's `python.uv_venv_auto = "source"` string form parses
+# fine but is silently ignored on mise 2026.7.x — verified against `mise env` in a uv project.
+uv_venv_auto = true
+
 [tools]
 # Languages
 bun  = "latest"


### PR DESCRIPTION
Adds `settings.python.uv_venv_auto` to the shared mise baseline, per the [mise + uv cookbook](https://mise.jdx.dev/mise-cookbook/python.html).

Entering a uv project now exports `VIRTUAL_ENV` (creating `.venv` if absent), so `source .venv/bin/activate` is no longer needed.

`uv` itself was already in `[tools]` (`uv = "latest"`, alongside `[settings.pipx] uvx = true`) — this is the missing half.

## Boolean, not the documented string

The cookbook shows:

```toml
[settings]
python.uv_venv_auto = "source"        # or "create|source"
```

On mise 2026.7.x that **parses as valid TOML and is silently ignored**. Verified against `mise env` in a real uv project:

| config | `VIRTUAL_ENV` exported? |
|---|---|
| `python.uv_venv_auto = true` | ✅ yes |
| `[settings.python] uv_venv_auto = true` | ✅ yes |
| `python.uv_venv_auto = "source"` | ❌ **no — silent no-op** |
| (no setting) | ❌ no |

`mise settings --all` also reports the default as a boolean `false`, not a string. Worth pinning down, since a silent no-op in the fleet-wide baseline would be invisible.

Used the `[settings.python]` subsection form to match the existing `[settings.github]` / `[settings.pipx]` style.

## Behavior confirmed

- **`uv.lock` is required.** mise walks up looking for it; a bare `.venv` with no lockfile is ignored. Run `uv sync` once in a new project.
- **Creates as well as sources.** With `uv.lock` present and `.venv` deleted, `true` recreated it — so the docs' `create|source` variant buys nothing on this version.
- **Non-uv directories unaffected** — no `VIRTUAL_ENV` leaks into unrelated dirs.
- PR #14's `idiomatic_version_file_enable_tools` and `node = "lts"` verified intact.
