### PR TITLE
feat(rtk): make the Claude hook a per-machine toggle (supersedes #13 + #16)

### DIFF
--- a/.chezmoitemplates/rtk-config.toml
+++ b/.chezmoitemplates/rtk-config.toml
@@ -1,87 +1,24 @@
+# rtk config -- deliberately minimal.
+#
+# Everything omitted here is rtk's own default (verified against a fresh
+# `rtk config --create`), so only settings carrying actual intent are pinned.
+#
+# There is no [hooks] section on purpose. rtk's exclude_commands and
+# transparent_prefixes are denylists, and when the Claude Code hook is enabled it
+# runs through ~/bin/rtk-allowlist-hook, which decides whether rtk is consulted
+# at all. Only commands named in ~/.config/rtk-allowlist.toml ever reach rtk, so
+# a denylist here would be unreachable policy -- and worse, a second place to
+# edit: allowing something in the allowlist stayed silently inert while rtk still
+# excluded it. One list, one file. With the hook disabled it is doubly moot,
+# since nothing invokes rtk except you.
+
 [tracking]
+# Powers `rtk gain`. With the hook on, that is the feedback loop for tuning the
+# allowlist; with it off, an honest answer to "is typing `rtk` myself worth it?"
 enabled = true
 history_days = 90
 
-[display]
-colors = true
-emoji = true
-max_width = 120
-
-[filters]
-ignore_dirs = [
-    ".git",
-    "node_modules",
-    "target",
-    "__pycache__",
-    ".venv",
-    "vendor",
-]
-ignore_files = [
-    "*.lock",
-    "*.min.js",
-    "*.min.css",
-]
-
-[tee]
-enabled = true
-mode = "failures"
-max_files = 20
-max_file_size = 1048576
-
 [telemetry]
-enabled = false
+enabled = false  # pinned, not merely defaulted, so an upgrade cannot opt us in
 consent_given = false
 consent_date = "2026-06-21T06:05:58.603291+00:00"
-
-[hooks]
-exclude_commands = [
-    "rg",  # rtk grep backend is BSD grep on macOS; rg flags break silently (exit 0)
-    "grep",  # 254/287 parse failures; 6.1K lifetime savings vs silent zero-match risk
-    "curl",  # 2 tokens saved on 138K input; schema-compaction risks mangling API responses
-    "diff",  # 28 parse failures vs 8 filtered runs; condensing strips hunk context
-]
-# git restricted to commit/fetch: compact filters strip output the model needs (e.g. stash SHA)
-transparent_prefixes = [
-    "git stash",
-    "git status",
-    "git log",
-    "git diff",
-    "git add",
-    "git push",
-    "git pull",
-    "git branch",
-    "git show",
-    "git worktree",
-    "git checkout",
-    "git switch",
-    "git restore",
-    "git reset",
-    "git merge",
-    "git rebase",
-    "git remote",
-    "git rev-parse",
-    "git tag",
-    "git blame",
-    "git ls-files",
-    "git ls-remote",
-    "git reflog",
-    "git cherry-pick",
-    "git describe",
-    "git config",
-    "git check-attr",
-    "git submodule",
-    "git clean",
-    "git rm",
-    "git mv",
-    "git init",
-    "git clone",
-    "git apply",
-    "git bisect",
-]
-
-[limits]
-grep_max_results = 200
-grep_max_per_file = 25
-status_max_files = 15
-status_max_untracked = 10
-passthrough_max_chars = 2000

--- a/2026_REFRESH.md
+++ b/2026_REFRESH.md
@@ -61,7 +61,7 @@ Old bash-specific files removed (git history preserved).
 | ripgrep (rg) | Better grep |
 | fzf | Fuzzy finder |
 | git-delta | Better git diff |
-| rtk | Token-optimizing CLI proxy for Claude Code (one-time `rtk init -g`, see below) |
+| rtk | Token-optimizing CLI proxy — always on PATH; automatic rewriting is a toggle (see below) |
 
 ### Brewfile Pared Down
 
@@ -115,27 +115,84 @@ cd ~/.dotfiles
 exec zsh
 ```
 
-### Post-install: wire rtk into Claude Code (one-time, per machine)
+### rtk: on PATH always, automatic only when asked
 
-`rtk` (the token-optimizing Claude Code proxy) installs fleet-wide via the mise
-baseline, but its Claude integration writes to `~/.claude/` — which chezmoi does
-not manage — so it needs a single manual step after install:
+`rtk` is a token-optimizing CLI proxy. It installs fleet-wide via the mise
+baseline and is always available to invoke directly — `rtk read foo` works on
+every machine. What is *optional*, and off by default, is the Claude Code hook
+that rewrites Bash commands before you see them.
 
 ```bash
-rtk init -g          # hook + RTK.md + @RTK.md in ~/.claude/CLAUDE.md + settings.json
-rtk init --show      # verify: all rows [ok]
+mise run rtk:hook           # enable: allowlisted commands get rewritten
+mise run rtk:unhook         # disable: nothing is rewritten automatically
+mise run rtk:hook:status    # what is actually wired, and any drift
+mise run rtk:uninstall      # remove rtk entirely (dry run; pass -- --yes)
 ```
 
-Idempotent — safe to re-run. Skips automation in the dotfiles repo on purpose so
-chezmoi never fights rtk over `~/.claude/CLAUDE.md` and `settings.json`.
+All four wrap `~/bin/rtk-hook` and `~/bin/rtk-uninstall`, which are runnable
+directly. Both directions back up every file they touch and are safe to re-run.
 
-rtk's own config *is* chezmoi-managed (`.chezmoitemplates/rtk-config.toml`, one
+**Why a toggle rather than a decision.** rtk *substitutes* rather than filters:
+it drops the wrapper and any argument it does not recognize.
+
+- `pnpm lint` → ran rtk's own eslint instead of the project's `lint` script
+- `pnpm exec prettier` → resolved `prettier` off `PATH`, not `node_modules/.bin`
+- `next build` → dropped `build` outright
+- a rewritten `grep` could hit a usage error rtk swallowed with **exit 0**, so a
+  search silently returned nothing
+
+Those are correctness bugs rather than overhead, and one silently-wrong result
+costs more than the filtering saves. But the savings are real too — `rtk gain`
+showed 4.7M tokens over 90 days, heavily concentrated in `cat`/`head`/`tail`.
+Both facts are true, and which one dominates depends on the machine and the
+week, so the posture is a switch rather than a verdict baked into the repo.
+
+Invoked deliberately, none of that ambiguity exists: you asked for `rtk read`,
+so you get `rtk read`. The hazard was always *automatic* substitution.
+
+**The allowlist.** When enabled, the Bash hook points at
+`~/bin/rtk-allowlist-hook` rather than rtk's own `rtk hook claude`. rtk ships
+only denylists (`exclude_commands`, `transparent_prefixes`), so every handler is
+armed by default and each release re-arms the surface — 0.43.0 added three new
+rewrite paths with no action on our side. The gate inverts that default: a
+command is rewritten only if `~/.config/rtk-allowlist.toml` names it, and only
+as the head of a single simple command. Anything with a pipe, `&&`, `;`, or a
+redirect passes through untouched.
+
+The list is short on purpose — `cat` `head` `tail` `ls` `gh` `find` `wc` `du`
+`ps` `vitest` `cargo`, plus `git commit` and `git fetch` — each earning its place
+in `rtk gain`. The whole JS toolchain is deliberately absent.
+
+**How the toggle sticks.** The choice is a marker file
+(`~/.config/rtk-hook-enabled`), per-machine and uncommitted. `chezmoi apply`
+runs `run_after_20-claude-rtk-hook.sh`, which *reconciles to the marker* rather
+than asserting the hook: enabled machines get their wiring repaired if it
+drifted, disabled machines are left alone. Without that gate a `chezmoi apply`
+would silently undo `rtk-unhook`. An absent marker means disabled, so a fresh
+machine gets rtk on PATH and no hook until it asks — the right default for a
+fleet that is mostly headless.
+
+**Migrating a machine that is already wired.** A machine hooked before the
+toggle existed has no marker, so `rtk:hook:status` reports a hook with no
+recorded intent and does nothing about it — `chezmoi apply` leaves such a
+machine exactly as-is. Run `mise run rtk:hook` once to keep the hook and record
+that choice, or `mise run rtk:unhook` to drop it.
+
+This also means `rtk init -g` is never run. It repoints the hook straight at
+`rtk hook claude`, re-arming everything, and overwrites `~/.claude/RTK.md`.
+`rtk-hook status` reports that drift if it happens.
+
+**Stats.** `rtk-hook disable --reset-history` wipes `history.db` so `rtk gain`
+restarts from zero. Worth doing when going opt-in: an existing database is
+mostly hook-driven traffic, which answers "did the hook save tokens?" — a
+question that stops mattering once it is off. Starting clean makes it answer "is
+invoking rtk by hand actually worth it?" instead.
+
+rtk's own config is chezmoi-managed (`.chezmoitemplates/rtk-config.toml`, one
 template → `~/.config/rtk/` on linux, `~/Library/Application Support/rtk/` on
-darwin). It dials the hook back to where filtering measurably pays off: `rg`,
-`grep`, `curl`, `diff` excluded (silent-failure risk or ~zero savings) and git
-restricted to `commit`/`fetch` via `transparent_prefixes` (compact filters
-stripped output the model needed, e.g. `git stash` SHAs). Verify a rewrite
-decision anytime with `rtk hook check "<cmd>"`.
+darwin). It pins telemetry off and carries **no** `[hooks]` section: with the
+allowlist deciding what reaches rtk, a denylist there is unreachable policy and
+a second place to edit.
 
 ## Verification
 

--- a/dot_claude/private_RTK.md.tmpl
+++ b/dot_claude/private_RTK.md.tmpl
@@ -1,0 +1,70 @@
+# rtk (Rust Token Killer)
+
+Token-optimizing CLI proxy. A `PreToolUse` hook rewrites a **small allowlist** of
+Bash commands to their `rtk` equivalent. Do not invoke `rtk <cmd>` by hand for
+these — the hook already does it, and typing it yourself just adds tokens.
+
+You are reading this because the hook is **enabled** on this machine. The
+`@RTK.md` include is added by `rtk-hook enable` and removed by `rtk-hook
+disable`, so when the hook is off these instructions are not in context at all.
+
+## What is rewritten
+
+Only these, and only as the head of a **single simple command**:
+
+`cat` `head` `tail` `ls` `gh` `find` `wc` `du` `ps` `vitest` `cargo`,
+plus `git commit` and `git fetch`.
+
+Everything else runs untouched — including `git status`, `git diff`, `git stash`,
+`rg`, `grep`, `curl`, `diff`, and the whole JS toolchain (`pnpm`, `npm`, `npx`,
+`yarn`, `tsc`, `eslint`, `prettier`). Anything with a pipe, `&&`, `;`, or a
+redirect is never rewritten, even if its first word is on the list.
+
+Write commands normally. The hook handles the rest.
+
+## Why the list is short
+
+rtk's handlers *substitute* rather than filter — they drop the wrapper and any
+argument they don't recognize (`pnpm lint` ran rtk's eslint instead of the
+project's script; `next build` dropped `build`). Commands are on the list only
+where they measurably saved tokens without changing behavior.
+
+To change what is rewritten, edit `~/.config/rtk-allowlist.toml` — not this file,
+and not rtk's own config.
+
+## Meta commands (run these directly)
+
+```bash
+rtk gain              # token savings analytics
+rtk gain --history    # per-command history with savings
+rtk proxy <cmd>       # run a command through rtk without filtering (debugging)
+```
+
+Check what the hook would actually do with a command:
+
+```bash
+echo '{"tool_name":"Bash","tool_input":{"command":"ls -la"}}' | ~/bin/rtk-allowlist-hook
+# prints the rewrite, or nothing at all when the command is not allowlisted
+```
+
+`rtk hook check "<cmd>"` shows rtk's *engine* view, which ignores the allowlist —
+it will report rewrites for commands the hook actually leaves alone.
+
+## Turning it off
+
+```bash
+mise run rtk:unhook        # or: rtk-hook disable
+mise run rtk:hook:status   # what's actually wired
+```
+
+Disabling leaves rtk on PATH — it just stops rewriting anything on its own.
+
+## Do not run `rtk init -g`
+
+It overwrites this file and repoints the Bash hook straight at `rtk hook claude`,
+re-arming every handler rtk ships. The wiring is managed by chezmoi instead:
+`chezmoi apply` re-asserts whatever `rtk-hook` last recorded, and
+`rtk-hook status` reports the drift if something has re-armed it.
+
+⚠️ Name collision: if `rtk gain` fails, you may have reachingforthejack/rtk
+(Rust Type Kit) installed instead of the token proxy.

--- a/dot_config/mise/conf.d/fresh.toml
+++ b/dot_config/mise/conf.d/fresh.toml
@@ -54,7 +54,10 @@ starship = "latest"
 # AI coding agents
 "aqua:openai/codex" = "latest"
 opencode = "latest"  # anomalyco/opencode
-rtk      = "latest"  # aqua:rtk-ai/rtk — token-optimizing CLI proxy for Claude Code.
+# rtk: always on PATH for explicit `rtk <cmd>` use. Whether it *also* rewrites
+# Bash commands automatically is a per-machine toggle, off until asked for:
+#   mise run rtk:hook / rtk:unhook / rtk:hook:status     (see 2026_REFRESH.md)
+rtk      = "latest"  # aqua:rtk-ai/rtk — token-optimizing CLI proxy.
 
 # Dotfiles management — must be in the committed baseline so a fresh machine's
 # install.sh (mise install -> chezmoi init) can bootstrap. (Previously chezmoi
@@ -91,3 +94,24 @@ taplo    = "latest"  # TOML
 # leiningen = "latest"  # optional: classic build tool, only if a project needs it
 # cljs builds run through shadow-cljs (npm, per-project) or figwheel; CIDER
 # connects to that REPL — no extra global tool needed.
+
+# --- Tasks -------------------------------------------------------------------
+# conf.d/*.toml counts as *global* mise config, so tasks defined here are global
+# tasks: runnable from any directory, no project file needed (mise 2026.7.5).
+# Args after `--` are appended to the run command.
+
+[tasks."rtk:hook"]
+description = "Enable rtk's Claude Code hook (allowlisted commands get rewritten)"
+run = '"$HOME/bin/rtk-hook" enable'
+
+[tasks."rtk:unhook"]
+description = "Disable it — rtk stays on PATH, nothing is rewritten automatically"
+run = '"$HOME/bin/rtk-hook" disable'
+
+[tasks."rtk:hook:status"]
+description = "Show whether rtk's hook is wired, and flag any drift"
+run = '"$HOME/bin/rtk-hook" status'
+
+[tasks."rtk:uninstall"]
+description = "Remove rtk entirely, wiring included (dry run; pass -- --yes)"
+run = '"$HOME/bin/rtk-uninstall"'

--- a/dot_config/rtk-allowlist.toml.tmpl
+++ b/dot_config/rtk-allowlist.toml.tmpl
@@ -1,0 +1,72 @@
+# Allowlist for ~/bin/rtk-allowlist-hook (Claude Code PreToolUse, Bash).
+#
+# rtk only ships denylists, so every handler it has is armed by default and each
+# release re-arms the surface. This file inverts that: a command is rewritten
+# only if it is named here. Everything else passes through untouched.
+#
+# Savings figures are from `rtk gain` over 90 days. Before adding an entry, check
+# it actually earns:  rtk gain --history | grep <cmd>
+# Check what a change does:  rtk hook check "<cmd>"   (engine view, ignores this file)
+# Check the real decision:
+#   echo '{"tool_name":"Bash","tool_input":{"command":"<cmd>"}}' | ~/bin/rtk-allowlist-hook
+# Empty output means no rewrite.
+#
+# Two layers have to agree. This file decides whether rtk is consulted at all;
+# rtk's own config still gets the final say. So adding something here that rtk
+# lists in `exclude_commands` or `transparent_prefixes` still will not rewrite --
+# e.g. allowing `git push` here is inert until it also comes off rtk's
+# transparent_prefixes. Both live in this repo:
+#   .chezmoitemplates/rtk-config.toml  (rtk's own denylists)
+#   this file                          (our allowlist gate)
+#
+# Only a single simple command is ever rewritten. Anything containing a pipe,
+# &&, ||, ;, redirection, backtick, or $(...) is passed through untouched --
+# rtk parses only the leading command, so on a compound line it would rewrite
+# the head and leave the rest inconsistent.
+#
+# This file only matters while the hook is enabled. To turn rewriting off
+# properly, unwire it -- `mise run rtk:unhook` (or `rtk-hook disable`). That
+# keeps rtk on PATH and `rtk gain` working; `mise run rtk:hook` puts it back.
+# Emptying `commands` here has a similar effect but leaves a hook running on
+# every Bash call to decide it has nothing to do, so prefer the toggle.
+
+# Rewritten whenever they are the head of a single simple command.
+commands = [
+    "cat",  # -> rtk read; with head/tail the largest single win, 3.0M tokens
+    "head",
+    "tail",
+    "ls",  # 593K saved, 66%
+    "gh",  # 224K saved, 61%
+    "find",  # 3.0K saved, 96%
+    "wc",  # 982 saved, 64%
+    "du",  # TOML filter, part of the 705K "other" bucket
+    "ps",  # same
+    "vitest",  # 48.9K saved, 100%; rtk passes --no-watch so dropping `run` is safe
+    "cargo",  # 5.7K saved, 98%
+]
+
+# Rewritten only for these subcommands. Global flags (`-C <path>`, `-c k=v`) are
+# skipped when locating the subcommand, so `git -C /tmp commit` still matches.
+[subcommands]
+# commit 88%, fetch 66%. Every other git subcommand loses output the model needs
+# -- `git stash` stopped printing the SHA, costing an extra rev-parse each time.
+git = ["commit", "fetch"]
+
+# Deliberately absent, and why:
+#   pnpm npm npx yarn bun tsc eslint prettier
+#     rtk substitutes its own handler and drops arguments -- `pnpm lint` ran
+#     rtk's eslint instead of the project script, `pnpm vitest run` dropped
+#     `run`. Combined lifetime savings: 0.1% of their input tokens.
+#   rg grep
+#     On 0.42.4 rtk ran BSD grep even when rg was invoked, so rg-only flags hit a
+#     usage error it swallowed with exit 0 and searches silently returned nothing.
+#     Fixed in 0.43.0 -- `rg foo` now runs rg -- so this pair is the most defensible
+#     candidate to re-add. Still out for now: grep was 254 of 287 lifetime parse
+#     failures for 6.1K tokens saved, and Claude Code's native Grep tool covers the
+#     same ground without a hook. Re-measure with `rtk gain --history` before adding.
+#   curl    2 tokens saved on 138K input.
+#   diff    strips hunk context; failed to parse 28 of 36 calls.
+#   tree df wget aws psql rsync make glab docker kubectl helm terraform go
+#   dotnet next pytest mypy ruff jest playwright prisma
+#     handlers rtk arms by default that were invoked zero times in 90 days.
+#     `next build` -> `rtk next` drops `build`, the same defect class as pnpm.

--- a/private_bin/executable_rtk-allowlist-hook
+++ b/private_bin/executable_rtk-allowlist-hook
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Allowlist gate in front of `rtk hook claude` (Claude Code PreToolUse, Bash).
+
+rtk only offers denylists (`exclude_commands`, `transparent_prefixes`), so every
+handler it ships is armed by default and each new release re-arms the surface.
+Its handlers *substitute* rather than filter -- they drop the wrapper and any
+argument they do not recognize:
+
+    pnpm lint          -> rtk lint     (rtk's eslint, not the project script)
+    pnpm exec prettier -> rtk prettier (PATH, not node_modules/.bin)
+    pnpm vitest run    -> rtk vitest   (drops `run`)
+    next build         -> rtk next     (drops `build`)
+
+This flips the polarity: nothing is rewritten unless it is named in ALLOW, and
+the entry has earned it in `rtk gain` history. rtk stays the rewrite engine --
+we only decide *whether* it gets consulted.
+
+Fails open everywhere. Any parse error, missing rtk, timeout, or unexpected
+exception prints nothing and exits 0, which Claude Code reads as "no rewrite".
+A hook that breaks must never break the user's command.
+"""
+
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+
+CONFIG_PATH = os.environ.get(
+    "RTK_ALLOWLIST_CONFIG",
+    os.path.expanduser("~/.config/rtk-allowlist.toml"),
+)
+
+# Used when the config is missing or unreadable, so a lost file degrades to the
+# known-good set rather than to rtk's wide-open default.
+DEFAULT_ALLOW = {
+    "cat", "head", "tail", "ls", "gh", "find", "wc", "du", "ps", "vitest", "cargo",
+}
+DEFAULT_SUBCOMMANDS = {"git": {"commit", "fetch"}}
+
+# Shell syntax that makes this more than one simple command. rtk parses only the
+# leading command, so on a pipeline or list it would rewrite the head and leave
+# the rest -- or mangle the whole string. We decline instead of guessing.
+SHELL_METACHARS = ("&&", "||", ";", "|", "`", "$(", ">", "<", "&", "\n")
+
+RTK_TIMEOUT_SECONDS = 10
+
+_ARRAY_RE = re.compile(r"^([A-Za-z0-9_-]+)\s*=\s*\[(.*?)\]", re.DOTALL | re.MULTILINE)
+_SECTION_RE = re.compile(r"^\s*\[([A-Za-z0-9_.-]+)\]\s*$", re.MULTILINE)
+_STRING_RE = re.compile(r'"([^"]*)"')
+
+
+def _parse_toml_subset(text: str) -> dict:
+    """Parse the `key = [...]` / `[section]` subset this config uses.
+
+    Only needed on Python < 3.11, which has no tomllib. Deliberately narrow: it
+    understands string arrays and one level of section, which is the whole
+    schema. Anything richer belongs in tomllib, not here.
+    """
+    # Strip comments, but not a '#' inside a quoted string.
+    lines = []
+    for line in text.splitlines():
+        out, in_string, index = [], False, 0
+        while index < len(line):
+            char = line[index]
+            if char == '"':
+                in_string = not in_string
+            elif char == "#" and not in_string:
+                break
+            out.append(char)
+            index += 1
+        lines.append("".join(out))
+    stripped = "\n".join(lines)
+
+    # Split into (section_name, body) chunks; the pre-header body is top level.
+    chunks, last_end, current = [], 0, None
+    for match in _SECTION_RE.finditer(stripped):
+        chunks.append((current, stripped[last_end:match.start()]))
+        current, last_end = match.group(1), match.end()
+    chunks.append((current, stripped[last_end:]))
+
+    result: dict = {}
+    for section, body in chunks:
+        target = result if section is None else result.setdefault(section, {})
+        if not isinstance(target, dict):
+            continue
+        for match in _ARRAY_RE.finditer(body):
+            target[match.group(1)] = _STRING_RE.findall(match.group(2))
+    return result
+
+
+def load_config(path: str = CONFIG_PATH):
+    """Return (allow_set, subcommand_map), falling back to the built-in defaults."""
+    try:
+        with open(path, "rb") as handle:
+            raw = handle.read()
+    except Exception:
+        return set(DEFAULT_ALLOW), {k: set(v) for k, v in DEFAULT_SUBCOMMANDS.items()}
+
+    data = None
+    try:
+        import tomllib  # Python 3.11+
+
+        data = tomllib.loads(raw.decode("utf-8"))
+    except ImportError:
+        try:
+            data = _parse_toml_subset(raw.decode("utf-8"))
+        except Exception:
+            data = None
+    except Exception:
+        data = None  # malformed TOML -- prefer the safe defaults over a wrong list
+
+    if not isinstance(data, dict):
+        return set(DEFAULT_ALLOW), {k: set(v) for k, v in DEFAULT_SUBCOMMANDS.items()}
+
+    commands = data.get("commands")
+    allow = (
+        {c for c in commands if isinstance(c, str) and c}
+        if isinstance(commands, list)
+        else set(DEFAULT_ALLOW)
+    )
+
+    subcommands = {}
+    raw_subcommands = data.get("subcommands")
+    if isinstance(raw_subcommands, dict):
+        for name, values in raw_subcommands.items():
+            if isinstance(values, list):
+                subcommands[name] = {v for v in values if isinstance(v, str) and v}
+
+    return allow, subcommands
+
+
+ALLOW, SUBCOMMANDS = load_config()
+
+# Global flags that consume the next token, so the subcommand scan skips past
+# their value instead of mistaking it for the subcommand.
+VALUE_FLAGS = ("-C", "-c", "--git-dir", "--work-tree", "--namespace")
+
+
+def is_allowed(command: str) -> bool:
+    """True only if `command` is a single simple command named in the allowlist."""
+    if not command or not command.strip():
+        return False
+
+    if any(tok in command for tok in SHELL_METACHARS):
+        return False
+
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        return False  # unbalanced quotes -- not ours to interpret
+
+    if not tokens:
+        return False
+
+    # Strip a leading `env`-style VAR=value prefix so `FOO=1 ls` still resolves.
+    while tokens and "=" in tokens[0] and not tokens[0].startswith("-"):
+        name = tokens[0].split("=", 1)[0]
+        if name and name.replace("_", "").isalnum():
+            tokens = tokens[1:]
+        else:
+            break
+
+    if not tokens:
+        return False
+
+    head = os.path.basename(tokens[0])
+
+    if head in SUBCOMMANDS:
+        # First non-flag token after the command is the subcommand. Value-taking
+        # global flags are skipped, so `git -C /tmp commit` resolves to `commit`
+        # rather than reading the path as the subcommand.
+        allowed = SUBCOMMANDS[head]
+        rest, index = tokens[1:], 0
+        while index < len(rest):
+            token = rest[index]
+            if not token.startswith("-"):
+                return token in allowed
+            index += 2 if token in VALUE_FLAGS else 1
+        return False  # bare `git` with no subcommand
+
+    return head in ALLOW
+
+
+def main() -> int:
+    try:
+        raw = sys.stdin.read()
+    except Exception:
+        return 0
+
+    try:
+        payload = json.loads(raw)
+    except Exception:
+        return 0
+
+    if not isinstance(payload, dict):
+        return 0
+    if payload.get("tool_name") != "Bash":
+        return 0
+
+    tool_input = payload.get("tool_input")
+    if not isinstance(tool_input, dict):
+        return 0
+
+    command = tool_input.get("command")
+    if not isinstance(command, str) or not is_allowed(command):
+        return 0  # no output == no rewrite
+
+    # Allowed: hand the untouched payload to rtk and relay its verdict verbatim.
+    try:
+        result = subprocess.run(
+            ["rtk", "hook", "claude"],
+            input=raw,
+            capture_output=True,
+            text=True,
+            timeout=RTK_TIMEOUT_SECONDS,
+        )
+    except Exception:
+        return 0  # rtk missing, not on PATH, or hung -- fall through to no rewrite
+
+    if result.returncode == 0 and result.stdout.strip():
+        sys.stdout.write(result.stdout)
+
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except Exception:
+        sys.exit(0)  # never let a hook failure block a command

--- a/private_bin/executable_rtk-hook
+++ b/private_bin/executable_rtk-hook
@@ -1,0 +1,436 @@
+#!/usr/bin/env bash
+# Turn rtk's Claude Code hook on and off.
+#
+# rtk is always installed and always usable by hand -- `rtk read foo` works
+# whatever this says. What toggles here is whether a PreToolUse hook rewrites
+# Bash commands *automatically*, before you see them.
+#
+#   rtk-hook enable     # allowlisted commands get rewritten
+#   rtk-hook disable    # nothing is rewritten; rtk runs only when you type it
+#   rtk-hook status     # what's actually wired right now
+#
+# Enabled routes Claude Code's Bash hook through ~/bin/rtk-allowlist-hook, which
+# rewrites only what ~/.config/rtk-allowlist.toml names. That gate exists because
+# rtk ships denylists only: every handler it has is armed by default, and each
+# release arms more. The allowlist inverts that default.
+#
+# The choice is recorded in a marker file and is per-machine, not committed --
+# chezmoi's run_after script reconciles the wiring to whatever the marker says,
+# so `chezmoi apply` re-asserts your choice instead of overriding it. Absent
+# marker means disabled: a fresh machine gets rtk on PATH and no hook until it
+# asks for one.
+#
+# Both directions back up every file they touch and are safe to re-run.
+
+set -uo pipefail
+
+# bash 3.2 (still /bin/bash on macOS) keeps the backslash in ${v/#$HOME/\~},
+# printing a literal \~. A plain variable sidesteps the escape.
+TILDE='~'
+
+MARKER="${XDG_CONFIG_HOME:-$HOME/.config}/rtk-hook-enabled"
+CLAUDE_DIR="$HOME/.claude"
+SETTINGS="$CLAUDE_DIR/settings.json"
+CLAUDE_MD="$CLAUDE_DIR/CLAUDE.md"
+ALLOWLIST="${XDG_CONFIG_HOME:-$HOME/.config}/rtk-allowlist.toml"
+GATE="$HOME/bin/rtk-allowlist-hook"
+
+# Must match run_after_20-claude-rtk-hook.sh and the removal matcher below.
+WRAPPER='if [ -x "$HOME/bin/rtk-allowlist-hook" ]; then "$HOME/bin/rtk-allowlist-hook"; fi'
+
+usage() {
+	cat <<'EOF'
+Usage: rtk-hook <enable|disable|status> [options]
+
+  enable    Wire Claude Code's Bash PreToolUse hook through the allowlist gate.
+            Only commands named in ~/.config/rtk-allowlist.toml are rewritten.
+  disable   Unwire it. rtk stays installed and on PATH; nothing is rewritten
+            unless you type `rtk <cmd>` yourself.
+  status    Show what is wired right now, and whether it matches the marker.
+
+Options:
+  --reset-history   (disable) Wipe history.db so `rtk gain` restarts from zero
+                    and counts only deliberate, opt-in runs.
+  --dry-run         Print what would change and change nothing.
+  --quiet           Print only when something actually changed. Used by the
+                    chezmoi run_after script so a clean apply stays silent.
+  -h, --help        Show this help.
+EOF
+}
+
+CMD="${1:-status}"
+[ $# -gt 0 ] && shift
+
+DRY=0
+RESET_HISTORY=0
+QUIET=0
+while [ $# -gt 0 ]; do
+	case "$1" in
+	--dry-run | -n) DRY=1 ;;
+	--reset-history) RESET_HISTORY=1 ;;
+	--quiet | -q) QUIET=1 ;;
+	--yes | -y) : ;; # accepted and ignored: acting is the default here
+	-h | --help)
+		usage
+		exit 0
+		;;
+	*)
+		echo "rtk-hook: unknown option: $1" >&2
+		usage >&2
+		exit 2
+		;;
+	esac
+	shift
+done
+
+if [ -t 1 ] && [ "${TERM:-dumb}" != "dumb" ]; then
+	BOLD=$(tput bold) DIM=$(tput dim) RESET=$(tput sgr0)
+else
+	BOLD="" DIM="" RESET=""
+fi
+
+say() { [ "$QUIET" -eq 1 ] || printf '%s\n' "$*"; }
+changed() { printf '%s\n' "$*"; } # always shown, even under --quiet
+act() { [ "$DRY" -eq 0 ]; }
+
+need_python() {
+	if ! command -v python3 >/dev/null 2>&1; then
+		echo "rtk-hook: python3 not available -- edit $SETTINGS by hand" >&2
+		return 1
+	fi
+}
+
+# --- enable ------------------------------------------------------------------
+do_enable() {
+	if [ ! -x "$GATE" ]; then
+		echo "rtk-hook: $GATE is missing or not executable." >&2
+		echo "          Run \`chezmoi apply\` first -- it installs the gate." >&2
+		exit 1
+	fi
+	need_python || exit 1
+
+	if act && [ ! -f "$MARKER" ]; then
+		mkdir -p "$(dirname "$MARKER")"
+		cat >"$MARKER" <<-EOF
+			# Presence of this file enables rtk's Claude Code Bash hook on this machine.
+			# Written by \`rtk-hook enable\`; removed by \`rtk-hook disable\`.
+			# Deliberately per-machine and uncommitted -- chezmoi's run_after script
+			# reconciles ~/.claude/settings.json to whatever this says.
+		EOF
+	fi
+
+	python3 - "$SETTINGS" "$CLAUDE_MD" "$WRAPPER" "$DRY" <<'PY'
+import json, os, shutil, sys
+
+settings_path, memory_path, wrapper, dry = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4] == "1"
+verb = "would add" if dry else "added"
+changes = []
+
+# Only ever rewrite an entry that is already rtk's (or already ours). A Bash
+# hook pointing at some other tool belongs to that tool and is left alone.
+RTK_COMMANDS = ("rtk hook claude", wrapper)
+
+try:
+    with open(settings_path) as fh:
+        settings = json.load(fh)
+except FileNotFoundError:
+    settings = {}
+except Exception as exc:
+    # Unparseable settings.json is never rewritten -- that risks destroying
+    # hand-edited config to add one hook.
+    print(f"rtk-hook: could not parse settings.json ({exc}); leaving it alone", file=sys.stderr)
+    sys.exit(1)
+
+hooks = settings.setdefault("hooks", {})
+pre = hooks.setdefault("PreToolUse", [])
+bash_entry = next((e for e in pre if isinstance(e, dict) and e.get("matcher") == "Bash"), None)
+
+if bash_entry is None:
+    pre.append({"matcher": "Bash", "hooks": [{"type": "command", "command": wrapper}]})
+    changes.append(f"{verb} Bash PreToolUse hook")
+else:
+    inner = bash_entry.setdefault("hooks", [])
+    existing = [h for h in inner if isinstance(h, dict) and h.get("command") in RTK_COMMANDS]
+    if not existing:
+        inner.append({"type": "command", "command": wrapper})
+        changes.append(f"{verb} allowlist hook alongside existing Bash hooks")
+    else:
+        for hook in existing:
+            if hook.get("command") != wrapper:
+                hook["command"] = wrapper
+                changes.append(f"{'would repoint' if dry else 'repointed'} Bash hook off `rtk hook claude`")
+
+if changes and not dry:
+    if os.path.exists(settings_path):
+        shutil.copyfile(settings_path, settings_path + ".rtk-hook.bak")
+    tmp = settings_path + ".tmp"
+    with open(tmp, "w") as fh:
+        json.dump(settings, fh, indent=2)
+        fh.write("\n")
+    os.replace(tmp, settings_path)   # atomic; never a half-written settings.json
+
+# --- the @RTK.md include -----------------------------------------------------
+# CLAUDE.md is the user's own global instruction file, so it is not
+# chezmoi-managed; only the include line is asserted, append-only.
+try:
+    with open(memory_path) as fh:
+        memory = fh.read()
+except FileNotFoundError:
+    memory = ""
+except Exception:
+    memory = None
+
+if memory is not None and "@RTK.md" not in memory:
+    if not dry:
+        with open(memory_path, "a") as fh:
+            if memory:
+                fh.write("\n" if memory.endswith("\n") else "\n\n")
+            fh.write("@RTK.md\n")
+    changes.append(f"{verb} @RTK.md include to CLAUDE.md")
+
+for c in changes:
+    print(f"    {c}")
+sys.exit(10 if changes else 0)
+PY
+	rc=$?
+	[ "$rc" -eq 1 ] && exit 1
+
+	if [ "$rc" -eq 10 ]; then
+		if act; then
+			changed "${BOLD}rtk hook enabled.${RESET} Restart Claude Code so it reloads settings.json."
+		else
+			say "Dry run -- nothing changed."
+		fi
+	else
+		say "Already enabled -- nothing to do."
+	fi
+	[ -f "$ALLOWLIST" ] || say "    ${DIM}note${RESET} $ALLOWLIST is missing; run \`chezmoi apply\`"
+}
+
+# --- disable -----------------------------------------------------------------
+do_disable() {
+	need_python || exit 1
+	local did=0
+
+	if [ -f "$MARKER" ]; then
+		did=1
+		if act; then
+			rm -f "$MARKER"
+		fi
+	fi
+
+	python3 - "$SETTINGS" "$CLAUDE_MD" "$DRY" <<'PY'
+import json, os, shutil, sys
+
+settings_path, memory_path, dry = sys.argv[1], sys.argv[2], sys.argv[3] == "1"
+verb = "would remove" if dry else "removed"
+RTK_MARKERS = ("rtk hook claude", "rtk-allowlist-hook")
+changes = []
+
+try:
+    with open(settings_path) as fh:
+        settings = json.load(fh)
+except FileNotFoundError:
+    settings = None
+except Exception as exc:
+    print(f"rtk-hook: could not parse settings.json ({exc}); leaving it alone", file=sys.stderr)
+    settings = None
+
+if isinstance(settings, dict):
+    hooks = settings.get("hooks")
+    if isinstance(hooks, dict):
+        removed = []
+        for event, groups in list(hooks.items()):
+            if not isinstance(groups, list):
+                continue
+            kept_groups = []
+            for group in groups:
+                entries = group.get("hooks") if isinstance(group, dict) else None
+                if not isinstance(entries, list):
+                    kept_groups.append(group)
+                    continue
+                kept = [e for e in entries
+                        if not (isinstance(e, dict)
+                                and any(m in str(e.get("command", "")) for m in RTK_MARKERS))]
+                if len(kept) != len(entries):
+                    removed.append(f"{event}[{group.get('matcher', '*')}]")
+                if kept:
+                    group["hooks"] = kept
+                    kept_groups.append(group)
+                # A group whose only entry was rtk's is dropped rather than left
+                # as an empty matcher shell. Foreign hooks always survive.
+            if kept_groups:
+                hooks[event] = kept_groups
+            else:
+                del hooks[event]
+
+        if removed:
+            changes.extend(f"{verb} hook entry {r}" for r in removed)
+            if not dry:
+                if not hooks:
+                    settings.pop("hooks", None)
+                shutil.copyfile(settings_path, settings_path + ".rtk-hook.bak")
+                tmp = settings_path + ".tmp"
+                with open(tmp, "w") as fh:
+                    json.dump(settings, fh, indent=2)
+                    fh.write("\n")
+                os.replace(tmp, settings_path)
+
+# --- the @RTK.md include -----------------------------------------------------
+# The include goes; ~/.claude/RTK.md itself is chezmoi-managed and stays put.
+# Uncited, it is inert -- and deleting it would only invite the next
+# `chezmoi apply` to put it straight back.
+try:
+    with open(memory_path) as fh:
+        lines = fh.readlines()
+except Exception:
+    lines = None
+
+if lines is not None:
+    kept = [ln for ln in lines if ln.strip() != "@RTK.md"]
+    if len(kept) != len(lines):
+        changes.append(f"{verb} the @RTK.md include from CLAUDE.md")
+        if not dry:
+            while kept and not kept[0].strip():
+                kept.pop(0)          # drop a blank line the include left stranded
+            shutil.copyfile(memory_path, memory_path + ".rtk-hook.bak")
+            tmp = memory_path + ".tmp"
+            with open(tmp, "w") as fh:
+                fh.writelines(kept)
+            os.replace(tmp, memory_path)
+
+for c in changes:
+    print(f"    {c}")
+sys.exit(10 if changes else 0)
+PY
+	[ $? -eq 10 ] && did=1
+
+	if [ "$RESET_HISTORY" -eq 1 ]; then
+		reset_history && did=1
+	fi
+
+	if [ "$did" -eq 1 ]; then
+		if act; then
+			# say(), not changed(): rtk-uninstall calls this with --quiet and
+			# relays the output, where "rtk stays on PATH" would contradict the
+			# removal in progress. The per-file lines above are signal enough.
+			say "${BOLD}rtk hook disabled.${RESET} Restart Claude Code so it reloads settings.json."
+			say "rtk stays on PATH -- it now runs only when you type it: ${BOLD}rtk <cmd>${RESET}"
+		else
+			say "Dry run -- nothing changed."
+		fi
+	else
+		say "Already disabled -- nothing to do."
+	fi
+}
+
+# rtk keeps config and history under the OS-native app dir; it ignores XDG on
+# darwin. Both are listed because a machine may carry either.
+rtk_data_dirs() {
+	case "$(uname -s)" in
+	Darwin) printf '%s\n' "$HOME/Library/Application Support/rtk" ;;
+	*) printf '%s\n%s\n' "${XDG_CONFIG_HOME:-$HOME/.config}/rtk" "${XDG_DATA_HOME:-$HOME/.local/share}/rtk" ;;
+	esac
+}
+
+reset_history() {
+	local found=0 d db
+	while IFS= read -r d; do
+		# The -shm/-wal sidecars go too, or sqlite replays them into a new db.
+		for db in "$d/history.db" "$d/history.db-shm" "$d/history.db-wal"; do
+			if [ -e "$db" ]; then
+				found=1
+				printf '    %s %s\n' "$([ "$DRY" -eq 1 ] && echo 'would remove' || echo removed)" "${db/#$HOME/$TILDE}"
+				act && rm -f "$db"
+			fi
+		done
+	done <<<"$(rtk_data_dirs)"
+	if [ "$found" -eq 1 ]; then
+		say "    config kept; \`rtk gain\` restarts from zero and counts only opt-in runs"
+		return 0
+	fi
+	say "    ${DIM}skip${RESET}  no history.db to reset"
+	return 1
+}
+
+# --- status ------------------------------------------------------------------
+do_status() {
+	local marker="disabled" wired="no" include="no"
+
+	[ -f "$MARKER" ] && marker="enabled"
+
+	if [ -f "$SETTINGS" ] && command -v python3 >/dev/null 2>&1; then
+		wired=$(
+			python3 - "$SETTINGS" <<'PY'
+import json, sys
+RTK_MARKERS = ("rtk hook claude", "rtk-allowlist-hook")
+try:
+    with open(sys.argv[1]) as fh:
+        hooks = json.load(fh).get("hooks") or {}
+except Exception:
+    print("unknown"); raise SystemExit
+for groups in hooks.values() if isinstance(hooks, dict) else []:
+    for group in groups if isinstance(groups, list) else []:
+        for e in (group.get("hooks") or []) if isinstance(group, dict) else []:
+            cmd = str(e.get("command", "")) if isinstance(e, dict) else ""
+            if any(m in cmd for m in RTK_MARKERS):
+                print("gate" if "rtk-allowlist-hook" in cmd else "raw `rtk hook claude`")
+                raise SystemExit
+print("no")
+PY
+		)
+	fi
+
+	grep -q '^@RTK\.md[[:space:]]*$' "$CLAUDE_MD" 2>/dev/null && include="yes"
+
+	printf '%srtk hook%s\n' "$BOLD" "$RESET"
+	printf '  marker         %s  %s\n' "$marker" "${DIM}(${MARKER/#$HOME/$TILDE})${RESET}"
+	printf '  settings.json  %s\n' "$wired"
+	printf '  @RTK.md        %s\n' "$include"
+	if [ -f "$ALLOWLIST" ]; then
+		printf '  allowlist      %s\n' "${ALLOWLIST/#$HOME/$TILDE}"
+	else
+		printf '  allowlist      %smissing -- run `chezmoi apply`%s\n' "$DIM" "$RESET"
+	fi
+	if command -v rtk >/dev/null 2>&1; then
+		printf '  rtk binary     %s\n' "$(command -v rtk)"
+	else
+		printf '  rtk binary     %snot on PATH%s\n' "$DIM" "$RESET"
+	fi
+
+	# The marker is the source of truth chezmoi reconciles to, so drift means a
+	# stray `rtk init -g` or a hand edit -- worth naming rather than papering over.
+	printf '\n'
+	if [ "$marker" = "enabled" ] && [ "$wired" = "no" ]; then
+		printf 'Drift: marker says enabled but nothing is wired. `rtk-hook enable` fixes it.\n'
+	elif [ "$marker" = "disabled" ] && [ "$wired" != "no" ] && [ "$wired" != "unknown" ]; then
+		# Two ways to land here: a machine wired before the marker existed, or
+		# something re-armed the hook behind your back. Both are resolved by
+		# saying which you want, so ask rather than accuse.
+		printf 'A hook is wired, but no marker records that as the intent -- either this\n'
+		printf 'machine was wired before the toggle existed, or something re-added it\n'
+		printf '(`rtk init -g`?). Say which you want:\n'
+		printf '  rtk-hook enable    keep it, and record the choice so apply respects it\n'
+		printf '  rtk-hook disable   unwire it\n'
+		printf 'Until then `chezmoi apply` leaves it exactly as-is.\n'
+	elif [ "$marker" = "enabled" ]; then
+		printf 'Allowlisted Bash commands are rewritten automatically.\n'
+	else
+		printf 'Nothing is rewritten. rtk runs only when you type `rtk <cmd>`.\n'
+	fi
+}
+
+case "$CMD" in
+enable) do_enable ;;
+disable) do_disable ;;
+status) do_status ;;
+-h | --help)
+	usage
+	exit 0
+	;;
+*)
+	echo "rtk-hook: unknown command: $CMD" >&2
+	usage >&2
+	exit 2
+	;;
+esac

--- a/private_bin/executable_rtk-uninstall
+++ b/private_bin/executable_rtk-uninstall
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# Remove rtk from this machine entirely -- wiring, config, history, binary.
+#
+# This is the nuclear option. If you only want to stop rtk rewriting your
+# commands, you almost certainly want the toggle instead:
+#
+#   rtk-hook disable      # keeps rtk on PATH for explicit `rtk <cmd>` use
+#
+# Uninstalling is for machines that should not carry rtk at all. The Claude Code
+# unwiring is delegated to `rtk-hook disable` so there is exactly one piece of
+# code that edits ~/.claude/settings.json.
+#
+# Dry run by default -- prints what it would do and changes nothing. Pass --yes
+# to actually act. Safe to re-run; every step no-ops when already clean.
+#
+# Also runnable directly as `rtk-uninstall` (~/bin is on PATH).
+
+set -uo pipefail
+
+# bash 3.2 (still /bin/bash on macOS) keeps the backslash in ${v/#$HOME/\~},
+# printing a literal \~. A plain variable sidesteps the escape.
+TILDE='~'
+
+APPLY=0
+
+usage() {
+	cat <<'EOF'
+Usage: rtk-uninstall [--yes]
+
+Removes rtk completely: the Claude Code hook and @RTK.md include, the files this
+repo installs for it, rtk's config and history directory, and the mise-installed
+binary.
+
+Options:
+  --yes, -y    Actually make changes (default is a dry run).
+  -h, --help   Show this help.
+
+To keep rtk installed and only stop it rewriting commands, use:
+  rtk-hook disable [--reset-history]
+EOF
+}
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+	--yes | -y) APPLY=1 ;;
+	--unhook)
+		echo "rtk-uninstall: --unhook moved -- use \`rtk-hook disable\` (or \`mise run rtk:unhook\`)." >&2
+		exit 2
+		;;
+	-h | --help)
+		usage
+		exit 0
+		;;
+	*)
+		echo "rtk-uninstall: unknown option: $1" >&2
+		usage >&2
+		exit 2
+		;;
+	esac
+	shift
+done
+
+# Ordinary terminals get color; pipes and dumb terminals get none.
+if [ -t 1 ] && [ "${TERM:-dumb}" != "dumb" ]; then
+	BOLD=$(tput bold) DIM=$(tput dim) RESET=$(tput sgr0)
+else
+	BOLD="" DIM="" RESET=""
+fi
+
+DID_ANYTHING=0
+say() { printf '%s\n' "$*"; }
+step() { printf '%s==>%s %s\n' "$BOLD" "$RESET" "$*"; }
+skip() { printf '    %sskip%s  %s\n' "$DIM" "$RESET" "$*"; }
+plan() {
+	DID_ANYTHING=1
+	if [ "$APPLY" -eq 1 ]; then
+		printf '    remove %s\n' "$*"
+	else
+		printf '    would remove %s\n' "$*"
+	fi
+}
+
+# rtk stores config and history under the OS-native app dir; it ignores XDG on
+# darwin. Both are listed because a machine may carry either.
+case "$(uname -s)" in
+Darwin) RTK_DATA_DIRS=("$HOME/Library/Application Support/rtk") ;;
+*) RTK_DATA_DIRS=("${XDG_CONFIG_HOME:-$HOME/.config}/rtk" "${XDG_DATA_HOME:-$HOME/.local/share}/rtk") ;;
+esac
+
+say ""
+if [ "$APPLY" -eq 0 ]; then
+	printf '%sDry run%s -- nothing will be changed. Re-run with --yes to apply.\n\n' "$BOLD" "$RESET"
+fi
+
+# 1. Claude Code wiring -------------------------------------------------------
+step "Claude Code wiring"
+if [ -x "$HOME/bin/rtk-hook" ]; then
+	# Captured rather than streamed so this step can report "nothing wired"
+	# instead of printing an empty section, and so a find still counts toward
+	# the summary. rtk-hook owns every edit to settings.json; this only relays.
+	if [ "$APPLY" -eq 1 ]; then
+		wiring=$("$HOME/bin/rtk-hook" disable --quiet 2>&1)
+	else
+		wiring=$("$HOME/bin/rtk-hook" disable --dry-run --quiet 2>&1)
+	fi
+	if [ -n "$wiring" ]; then
+		DID_ANYTHING=1
+		printf '%s\n' "$wiring"
+	else
+		skip "nothing wired into Claude Code"
+	fi
+else
+	skip "~/bin/rtk-hook not present -- check ~/.claude/settings.json by hand"
+fi
+
+# 2. Files this repo installs for rtk ----------------------------------------
+# ~/bin/rtk-uninstall is deliberately absent: deleting the script mid-run reads
+# worse than it behaves, and chezmoi restores it anyway until the source stops
+# shipping it -- which is exactly what the note below is about.
+step "rtk files"
+for f in \
+	"$HOME/bin/rtk-hook" \
+	"$HOME/bin/rtk-allowlist-hook" \
+	"$HOME/.config/rtk-allowlist.toml" \
+	"$HOME/.config/rtk-hook-enabled" \
+	"$HOME/.claude/RTK.md"; do
+	if [ -e "$f" ]; then
+		plan "${f/#$HOME/$TILDE}"
+		[ "$APPLY" -eq 1 ] && rm -f "$f"
+	fi
+done
+
+step "rtk config + history"
+for d in "${RTK_DATA_DIRS[@]}"; do
+	if [ -d "$d" ]; then
+		plan "${d/#$HOME/$TILDE}  (config + history.db)"
+		[ "$APPLY" -eq 1 ] && rm -rf "$d"
+	fi
+done
+
+# chezmoi manages most of what step 2 just deleted, so removing it while the
+# source still ships it means the next `chezmoi apply` puts it straight back --
+# say so rather than reporting a clean uninstall that will not stay clean.
+if command -v chezmoi >/dev/null 2>&1; then
+	if chezmoi managed 2>/dev/null | grep -q 'rtk'; then
+		say ""
+		say "    ${BOLD}note${RESET} chezmoi still manages rtk paths on this machine, so the next"
+		say "         apply will recreate them. Drop rtk from the dotfiles source first"
+		say "         (or run \`chezmoi forget\` on those paths) to make this stick."
+	fi
+fi
+
+# 3. The binary ---------------------------------------------------------------
+step "rtk binary"
+if ! command -v mise >/dev/null 2>&1; then
+	skip "mise not found -- remove rtk however it was installed"
+elif ! mise ls --installed 2>/dev/null | grep -q '^rtk[[:space:]]'; then
+	skip "rtk not installed via mise"
+else
+	plan "the mise-installed rtk toolchain"
+	if [ "$APPLY" -eq 1 ]; then
+		# --all covers every installed version, not just the active one.
+		mise uninstall --all rtk 2>&1 | sed 's/^/    /'
+	fi
+fi
+
+say ""
+if [ "$DID_ANYTHING" -eq 0 ]; then
+	say "Nothing to do -- rtk is already gone."
+elif [ "$APPLY" -eq 1 ]; then
+	say "${BOLD}Done.${RESET} Restart Claude Code so it reloads settings.json."
+else
+	say "Re-run with ${BOLD}--yes${RESET} to apply:  mise run rtk:uninstall -- --yes"
+fi
+say ""

--- a/run_after_20-claude-rtk-hook.sh
+++ b/run_after_20-claude-rtk-hook.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# Reconcile rtk's Claude Code hook to this machine's choice, on every apply.
+#
+# The choice lives in a marker file written by `rtk-hook enable` / removed by
+# `rtk-hook disable`. This script only re-asserts it -- it never decides.
+#
+#   marker present  ->  `rtk-hook enable` repairs the wiring if it drifted
+#   marker absent   ->  do nothing at all
+#
+# That asymmetry is deliberate. An earlier draft asserted the hook on every
+# apply unconditionally, which would have silently undone `rtk-hook disable` on
+# the next `chezmoi apply`. Gating on the marker makes the toggle stick.
+#
+# Absent marker means "not enabled here", so a fresh machine gets rtk on PATH
+# and no hook until it asks for one -- the right default for a fleet that is
+# mostly headless. It also means this never *removes* a hook: someone who ran
+# `rtk init -g` by hand keeps what they wired until they run `rtk-hook disable`,
+# which `rtk-hook status` will point out.
+#
+# No-ops silently when Claude Code isn't installed.
+
+set -eu
+
+[ -d "$HOME/.claude" ] || exit 0
+[ -f "${XDG_CONFIG_HOME:-$HOME/.config}/rtk-hook-enabled" ] || exit 0
+[ -x "$HOME/bin/rtk-hook" ] || exit 0
+
+# --quiet keeps a clean apply silent; it prints only when it actually repairs.
+"$HOME/bin/rtk-hook" enable --quiet


### PR DESCRIPTION
Combines #13 and #16. They were framed as alternatives, but they are the two
halves of one switch: #13's allowlist is the *enabled* state, #16's unhook is
the *disabled* one. Neither has to win.

```bash
mise run rtk:hook          # allowlisted commands get rewritten
mise run rtk:unhook        # nothing is rewritten automatically
mise run rtk:hook:status   # what is wired, and any drift
mise run rtk:uninstall     # remove rtk altogether (dry run; pass -- --yes)
```

`rtk` stays on PATH in every state — `rtk read foo` always works. Only
*automatic* rewriting toggles, because that was the actual hazard: rtk
substitutes rather than filters, so `pnpm lint` ran rtk's eslint and
`next build` dropped `build`. Typed on purpose, that ambiguity is gone.

## The problem this had to solve

#13 installed the hook from a `run_after` script that re-asserted it on **every
`chezmoi apply`**. Dropped in next to a disable command, that silently undoes
the disable on the next apply.

So the choice is now a marker file (`~/.config/rtk-hook-enabled`, per-machine
and uncommitted), and `run_after` *reconciles to the marker* rather than
asserting the hook:

| marker | `chezmoi apply` does |
|---|---|
| present | repairs the wiring if it drifted |
| absent | nothing at all |

Absent marker means disabled, so a fresh machine gets rtk on PATH and no hook
until it asks — the right default for a fleet that's mostly headless. It also
means apply never *removes* a hook someone wired by hand.

## Structure

One script owns every edit to `~/.claude/settings.json`. `rtk-uninstall`
delegates its unwiring to `rtk-hook disable` rather than carrying a second copy
of the JSON surgery (#16 had its own). `--unhook` is gone from `rtk-uninstall`;
it errors with a pointer to `rtk-hook disable`.

- `~/bin/rtk-hook` — `enable` / `disable` / `status`, plus `--reset-history`
- `~/bin/rtk-uninstall` — full removal, dry-run by default
- `run_after_20-claude-rtk-hook.sh` — 3-line reconcile shim

## Migration

Your machine is already wired from the merged rtk branch but has no marker, so
`status` reports a hook with no recorded intent and **does nothing about it**:

```
A hook is wired, but no marker records that as the intent -- either this
machine was wired before the toggle existed, or something re-added it
(`rtk init -g`?). Say which you want:
  rtk-hook enable    keep it, and record the choice so apply respects it
  rtk-hook disable   unwire it
Until then `chezmoi apply` leaves it exactly as-is.
```

One run of `mise run rtk:hook` or `mise run rtk:unhook` settles it.

## Verification

Sandboxed `HOME` with stub binaries — the real toolchain and home were never
mutated. Run under **bash 3.2** (macOS `/bin/bash`) as well as bash 5:

- enable / disable / status; idempotent re-runs
- foreign `SessionStart` + a foreign `PreToolUse[Bash]` sibling preserved in both directions
- clean `chezmoi apply` stays silent; drift gets repaired
- **disable survives apply** (the case that motivated the marker)
- `rtk init -g`-style raw hook repointed to the gate
- unparseable `settings.json` left untouched
- dry runs byte-for-byte no-op (checksum-verified)
- full `--yes` uninstall leaves unrelated hooks and CLAUDE.md content intact

Two bugs were caught by testing under bash 3.2 specifically and are fixed:
`${v/#$HOME/\~}` printed a literal `\~` there, and the uninstaller's wiring step
printed an empty section because its output was swallowed by `grep -q`.

`taplo fmt --check` still fails on `fresh.toml` — pre-existing on `main` (manual
`=` alignment), verified against `origin/main`, left alone.

## Not applied

Nothing has been changed on the real machine. Recommended order is merge (or
`chezmoi update`) first, then pick a state — otherwise a later apply could
recreate files this removes.

Supersedes #13 and #16; both can close if this lands.
