### PR TITLE
chore(fmt): fix taplo/shfmt drift, pin formatter config

### DIFF
--- a/.chezmoitemplates/rtk-config.toml
+++ b/.chezmoitemplates/rtk-config.toml
@@ -15,10 +15,10 @@
 [tracking]
 # Powers `rtk gain`. With the hook on, that is the feedback loop for tuning the
 # allowlist; with it off, an honest answer to "is typing `rtk` myself worth it?"
-enabled = true
+enabled      = true
 history_days = 90
 
 [telemetry]
-enabled = false  # pinned, not merely defaulted, so an upgrade cannot opt us in
+enabled       = false                              # pinned, not merely defaulted, so an upgrade cannot opt us in
 consent_given = false
-consent_date = "2026-06-21T06:05:58.603291+00:00"
+consent_date  = "2026-06-21T06:05:58.603291+00:00"

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# Read by editors and, importantly, by shfmt: with no -i/-ln flags, shfmt takes
+# indentation from here, so `shfmt -d .` agrees with format-on-save.
+# This file only describes the two indent dialects already in the repo; it is
+# not an attempt to unify them.
+
+# private_bin/ scripts are tab-indented (shfmt's own default).
+[*]
+indent_style = tab
+
+# install.sh and the sourced shell/ fragments are 4-space indented.
+[{install.sh,shell/*.sh}]
+indent_style = space
+indent_size = 4

--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,0 +1,11 @@
+# taplo (TOML formatter) settings for this repo.
+# Emacs/apheleia and a manual `taplo fmt` both read this, so format-on-save and
+# a check run agree. taplo itself is installed via dot_config/mise/conf.d/fresh.toml.
+#
+# Both keys are here to be explicit rather than to override a default:
+# align_comments is already taplo's default, align_entries is NOT — without it
+# taplo collapses the hand-aligned `key   = value` columns this repo uses.
+
+[formatting]
+align_entries  = true # preserve the aligned `=` columns in the mise / rtk configs
+align_comments = true # trailing `# why` comments line up within a block

--- a/2026_REFRESH.md
+++ b/2026_REFRESH.md
@@ -8,10 +8,12 @@ originally bash-focused using Bash-It framework. Time to modernize.
 ## Future Plans
 
 ### Shell sugar (not yet adopted)
+
 - **zsh-autosuggestions** - Fish-like suggestions as you type
 - **zsh-syntax-highlighting** - Command highlighting
 
 ### iTerm2 prefs management (punted)
+
 Ghostty is the primary terminal (`~/.config/ghostty/config`, chezmoi-managed).
 iTerm2 stays installed as a secondary for `tmux -CC` control mode; its prefs
 plist is intentionally **not** managed yet. Revisit if it earns a permanent seat.
@@ -21,15 +23,18 @@ plist is intentionally **not** managed yet. Revisit if it earns a permanent seat
 ## What Changed
 
 ### Shell: bash → zsh
+
 - Primary config: `~/.zshrc` (was `~/.bash_profile`)
 - History: `~/.zsh_history` with zsh-specific options
 - Completions: Native zsh completion system
 
 ### Architecture: Intel → Apple Silicon
+
 - Homebrew location: `/opt/homebrew` (was `/usr/local`)
 - Universal path handling for both architectures
 
 ### Directory Structure
+
 ```
 bash/           →  shell/           # Shell-agnostic configs
 ├── exports.bash    ├── exports.sh
@@ -42,30 +47,31 @@ Old bash-specific files removed (git history preserved).
 
 ### Tools Replaced
 
-| Old | New | Why |
-|-----|-----|-----|
-| Fresh | chezmoi | Per-machine templating; no build step; active project |
-| nvm | mise | Polyglot, fast, no shell-startup penalty |
-| Bash-It themes | Starship | Cross-shell, fast, configurable |
-| fasd | zoxide | Faster, maintained, better algorithm |
-| hub | gh | Official GitHub CLI |
-| reattach-to-user-namespace | (removed) | Not needed since tmux 2.6 |
-| Python 2 http.server | Python 3 | Python 2 EOL |
+| Old                        | New       | Why                                                   |
+| -------------------------- | --------- | ----------------------------------------------------- |
+| Fresh                      | chezmoi   | Per-machine templating; no build step; active project |
+| nvm                        | mise      | Polyglot, fast, no shell-startup penalty              |
+| Bash-It themes             | Starship  | Cross-shell, fast, configurable                       |
+| fasd                       | zoxide    | Faster, maintained, better algorithm                  |
+| hub                        | gh        | Official GitHub CLI                                   |
+| reattach-to-user-namespace | (removed) | Not needed since tmux 2.6                             |
+| Python 2 http.server       | Python 3  | Python 2 EOL                                          |
 
 ### Tools Added
 
-| Tool | Purpose |
-|------|---------|
-| bat | Better cat with syntax highlighting |
-| fd | Better find |
-| ripgrep (rg) | Better grep |
-| fzf | Fuzzy finder |
-| git-delta | Better git diff |
-| rtk | Token-optimizing CLI proxy — always on PATH; automatic rewriting is a toggle (see below) |
+| Tool         | Purpose                                                                                  |
+| ------------ | ---------------------------------------------------------------------------------------- |
+| bat          | Better cat with syntax highlighting                                                      |
+| fd           | Better find                                                                              |
+| ripgrep (rg) | Better grep                                                                              |
+| fzf          | Fuzzy finder                                                                             |
+| git-delta    | Better git diff                                                                          |
+| rtk          | Token-optimizing CLI proxy — always on PATH; automatic rewriting is a toggle (see below) |
 
 ### Brewfile Pared Down
 
 Removed deprecated packages and trimmed to essentials:
+
 - `boot2docker`, `docker-machine`, `fig` (old Docker tooling)
 - `reattach-to-user-namespace` (tmux workaround)
 - `mongodb` with args (needs tap now)
@@ -77,11 +83,12 @@ Removed deprecated packages and trimmed to essentials:
 
 Retired [Fresh](http://freshshell.com/) in favor of [chezmoi](https://www.chezmoi.io/)
 (`mode = "symlink"`). GNU Stow was considered and rejected — the recurring pain in
-this repo is *per-machine state* (mise `config.local.toml`, git user identity,
+this repo is _per-machine state_ (mise `config.local.toml`, git user identity,
 future work/personal split), which chezmoi templates solve natively and Stow does
 not. See `CHEZMOI_MIGRATION.md` for the full rationale and cut-over log.
 
 How it maps (source name → target):
+
 - `dot_zshrc` → `~/.zshrc`; `.zshrc` sources `shell/*.sh` directly from `$DOTFILES`
   (those helpers stay outside chezmoi's tree via `.chezmoiignore`).
 - `dot_gitconfig.tmpl` → `~/.gitconfig` (templated; folds in user identity from
@@ -124,7 +131,7 @@ exec zsh
 
 `rtk` is a token-optimizing CLI proxy. It installs fleet-wide via the mise
 baseline and is always available to invoke directly — `rtk read foo` works on
-every machine. What is *optional*, and off by default, is the Claude Code hook
+every machine. What is _optional_, and off by default, is the Claude Code hook
 that rewrites Bash commands before you see them.
 
 ```bash
@@ -137,7 +144,7 @@ mise run rtk:uninstall      # remove rtk entirely (dry run; pass -- --yes)
 All four wrap `~/bin/rtk-hook` and `~/bin/rtk-uninstall`, which are runnable
 directly. Both directions back up every file they touch and are safe to re-run.
 
-**Why a toggle rather than a decision.** rtk *substitutes* rather than filters:
+**Why a toggle rather than a decision.** rtk _substitutes_ rather than filters:
 it drops the wrapper and any argument it does not recognize.
 
 - `pnpm lint` → ran rtk's own eslint instead of the project's `lint` script
@@ -153,7 +160,7 @@ Both facts are true, and which one dominates depends on the machine and the
 week, so the posture is a switch rather than a verdict baked into the repo.
 
 Invoked deliberately, none of that ambiguity exists: you asked for `rtk read`,
-so you get `rtk read`. The hazard was always *automatic* substitution.
+so you get `rtk read`. The hazard was always _automatic_ substitution.
 
 **The allowlist.** When enabled, the Bash hook points at
 `~/bin/rtk-allowlist-hook` rather than rtk's own `rtk hook claude`. rtk ships
@@ -170,7 +177,7 @@ in `rtk gain`. The whole JS toolchain is deliberately absent.
 
 **How the toggle sticks.** The choice is a marker file
 (`~/.config/rtk-hook-enabled`), per-machine and uncommitted. `chezmoi apply`
-runs `run_after_20-claude-rtk-hook.sh`, which *reconciles to the marker* rather
+runs `run_after_20-claude-rtk-hook.sh`, which _reconciles to the marker_ rather
 than asserting the hook: enabled machines get their wiring repaired if it
 drifted, disabled machines are left alone. Without that gate a `chezmoi apply`
 would silently undo `rtk-unhook`. An absent marker means disabled, so a fresh
@@ -198,6 +205,41 @@ template → `~/.config/rtk/` on linux, `~/Library/Application Support/rtk/` on
 darwin). It pins telemetry off and carries **no** `[hooks]` section: with the
 allowlist deciding what reaches rtk, a denylist there is unreachable policy and
 a second place to edit.
+
+### Formatting
+
+Four formatters, one file type each, all installed via mise and all usable from
+Emacs (apheleia) or the shell:
+
+| Type     | Tool       | Config          |
+| -------- | ---------- | --------------- |
+| TOML     | `taplo`    | `.taplo.toml`   |
+| shell    | `shfmt`    | `.editorconfig` |
+| Markdown | `oxfmt`    | (defaults)      |
+| TS/JSON  | `prettier` | (defaults)      |
+
+```bash
+taplo fmt --check          # TOML
+shfmt -d install.sh shell/*.sh private_bin/*   # shell (skips the python ones)
+oxfmt --check **/*.md      # Markdown
+```
+
+Two decisions worth knowing:
+
+- **`align_entries = true`** in `.taplo.toml`. taplo's default collapses the
+  hand-aligned `=` columns in `fresh.toml`; this keeps them. The cost is that
+  taplo column-aligns trailing `# why` comments rather than leaving them at a
+  fixed two spaces.
+- **`.editorconfig` records two indent dialects** — `private_bin/*` uses tabs,
+  `install.sh` and `shell/*.sh` use four spaces — rather than unifying them.
+  shfmt reads it, so a bare `shfmt -d` respects both.
+
+`oxfmt` handles Markdown rather than prettier. It delegates `.md` to prettier
+internally, so output is near-identical (verified byte-for-byte on this repo's
+files, bar one case where oxfmt correctly leaves `*` unescaped inside a table
+cell). It is one binary for the job and much faster. Note that prettier's
+Markdown defaults normalize `*emphasis*` to `_emphasis_` and re-pad every table
+— that reflow is the bulk of any Markdown diff.
 
 ## Verification
 

--- a/CHEZMOI_MIGRATION.md
+++ b/CHEZMOI_MIGRATION.md
@@ -17,7 +17,7 @@ diverged from the plan below.
 Mental model:
 
 - **Source state**: a directory holding your dotfiles in chezmoi's naming convention (`dot_zshrc` not `.zshrc`, `dot_config/starship.toml` not `.config/starship.toml`). Default location is `~/.local/share/chezmoi`; we'll keep ours at `~/.dotfiles`.
-- **Target state**: what chezmoi *would* produce in `$HOME` after applying templates and decoding the naming attributes.
+- **Target state**: what chezmoi _would_ produce in `$HOME` after applying templates and decoding the naming attributes.
 - **Destination state**: what's actually in `$HOME` right now.
 - `chezmoi apply` reconciles destination → target.
 - `chezmoi diff` shows the gap. `chezmoi status` shows it briefly. `chezmoi edit <target>` opens the source file (with the right name mapping) in your editor. `chezmoi re-add` pulls a destination edit back into source.
@@ -45,14 +45,14 @@ chezmoi cd                     # drop a shell in the source dir
 
 ## What Fresh did, mapped to chezmoi
 
-| Fresh feature | Used for | chezmoi mechanism |
-|---|---|---|
-| Mirror (`fresh path/to/file --file=~/dest`) | `git/.gitconfig` → `~/.gitconfig` | source naming: `dot_gitconfig` |
-| Rename (`shell/exports.sh` → `~/.exports`) | shell helpers | Doesn't need a rename — `.zshrc` sources from `$DOTFILES/shell/*.sh` directly (kept outside chezmoi's tree via `.chezmoiignore`) |
-| Concatenate (gitconfig + gituserconfig) | git includes | Templated `dot_gitconfig.tmpl` with prompts on init |
-| Concatenate (tmux.conf + tmux-colors-solarized) | tmux config | `dot_tmux.conf` has `source-file ~/.dotfiles/tmux/tmuxcolors-dark.conf` (vendored, ignored by chezmoi) |
-| Pull from external git repos (seebi/*) | colors files | Vendor into repo; ignore from chezmoi |
-| `--bin` (link executables) | `~/bin/dotfiles` | `install.sh` adds the symlink. Doesn't belong in chezmoi-managed state |
+| Fresh feature                                   | Used for                          | chezmoi mechanism                                                                                                                |
+| ----------------------------------------------- | --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| Mirror (`fresh path/to/file --file=~/dest`)     | `git/.gitconfig` → `~/.gitconfig` | source naming: `dot_gitconfig`                                                                                                   |
+| Rename (`shell/exports.sh` → `~/.exports`)      | shell helpers                     | Doesn't need a rename — `.zshrc` sources from `$DOTFILES/shell/*.sh` directly (kept outside chezmoi's tree via `.chezmoiignore`) |
+| Concatenate (gitconfig + gituserconfig)         | git includes                      | Templated `dot_gitconfig.tmpl` with prompts on init                                                                              |
+| Concatenate (tmux.conf + tmux-colors-solarized) | tmux config                       | `dot_tmux.conf` has `source-file ~/.dotfiles/tmux/tmuxcolors-dark.conf` (vendored, ignored by chezmoi)                           |
+| Pull from external git repos (seebi/*)          | colors files                      | Vendor into repo; ignore from chezmoi                                                                                            |
+| `--bin` (link executables)                      | `~/bin/dotfiles`                  | `install.sh` adds the symlink. Doesn't belong in chezmoi-managed state                                                           |
 
 ## Proposed source layout
 
@@ -104,7 +104,7 @@ Keep the repo at `~/.dotfiles`. chezmoi reads it via `--source ~/.dotfiles` (set
 
 ## `~/.config/chezmoi/chezmoi.toml.tmpl` (init prompts)
 
-This is what `chezmoi init` evaluates *first* — it asks questions, records the answers in `~/.config/chezmoi/chezmoi.toml`, and every other template can read from `{{ .* }}`.
+This is what `chezmoi init` evaluates _first_ — it asks questions, records the answers in `~/.config/chezmoi/chezmoi.toml`, and every other template can read from `{{ .* }}`.
 
 ```go-template
 {{- $name := promptStringOnce . "name" "Full name" -}}
@@ -168,7 +168,7 @@ target="$HOME/.iterm2_shell_integration.zsh"
 
 ## `.chezmoiignore`
 
-Keeps directories that are *referenced* by chezmoi-managed files (shell helpers, vendored colors, bootstrap script) out of the apply pass:
+Keeps directories that are _referenced_ by chezmoi-managed files (shell helpers, vendored colors, bootstrap script) out of the apply pass:
 
 ```
 README.md
@@ -190,7 +190,7 @@ git
 mise
 ```
 
-(The lowercased dirs here are the *source-side* directories whose contents are referenced by managed files but don't themselves represent target files. Confusing for one read; once you've internalized the `dot_` convention it's obvious.)
+(The lowercased dirs here are the _source-side_ directories whose contents are referenced by managed files but don't themselves represent target files. Confusing for one read; once you've internalized the `dot_` convention it's obvious.)
 
 ## `.zshrc` patch (replaces Fresh sourcing)
 
@@ -248,6 +248,7 @@ echo "Verify: chezmoi status (should be empty)"
 ```
 
 Gone vs current `install.sh`:
+
 - `source ~/.fresh/build/shell.sh`
 - `cp ~/.dotfiles/.freshrc ~/.freshrc`
 - `fresh install`
@@ -258,28 +259,28 @@ Gone vs current `install.sh`:
 
 ## File-by-file mapping
 
-| Today | After migration | Notes |
-|---|---|---|
-| `zsh/.zshrc` | `dot_zshrc` | rename, edit per .zshrc patch above |
-| `shell/*.sh` | `shell/*.sh` (unchanged) | not under chezmoi; sourced from `.zshrc` via `$DOTFILES` |
-| `git/.gitconfig` | `dot_gitconfig.tmpl` | templated; absorbs `.gituserconfig` |
-| `git/.gitattributes` | `dot_gitattributes` | rename |
-| `git/.gitignore` | `dot_gitignore` | rename |
-| `git/.gituserconfig` | gone — folded into chezmoi data via init prompts | per-machine answers stored in `~/.config/chezmoi/chezmoi.toml` (gitignored by chezmoi by default) |
-| `tmux/.tmux.conf` | `dot_tmux.conf` | rename; add `source-file` line |
-| seebi tmux colors | `tmux/tmuxcolors-dark.conf` (vendored) | ignored by chezmoi |
-| `.inputrc` | `dot_inputrc` | rename |
-| `emacs/init.el` | `dot_emacs.d/init.el` | newly managed; refresh package archives (drop marmalade, https melpa) |
-| (live) `~/.config/ghostty/config` | `dot_config/ghostty/config` | newly managed; primary terminal (cmux/Ghostty), `iTerm2 Solarized Dark` theme |
-| `starship/starship.toml` | `dot_config/starship.toml` | path mirrors target |
-| seebi dircolors | `shell/dircolors.ansi-universal` (vendored) | ignored |
-| `mise/fresh.toml` | `dot_config/mise/conf.d/fresh.toml` | path mirrors target |
-| `mise/config.toml` | `dot_config/mise/config.toml.tmpl` | templated |
-| `mise/config.local.toml` | `dot_config/mise/config.local.toml.tmpl` | templated |
-| `install.sh` | `install.sh` (root); `~/bin/dotfiles` via `bin/symlink_dotfiles` | script not managed; the ~/bin symlink is |
-| `bin/symlinks/subl,subl3` | `bin/symlink_subl.tmpl` → `~/bin/subl`; drop `subl3` | chezmoi `symlink_`, darwin-gated via `.chezmoiignore` |
-| `bin/crossOriginChrome.sh` | `bin/executable_cross_origin_chrome` → `~/bin/cross_origin_chrome` | renamed snake_case, no ext; chezmoi `executable_` sets +x |
-| iTerm2 integration curl | `run_once_before_10-iterm2-shell-integration.sh.tmpl` | chezmoi tracks state |
+| Today                             | After migration                                                    | Notes                                                                                             |
+| --------------------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------- |
+| `zsh/.zshrc`                      | `dot_zshrc`                                                        | rename, edit per .zshrc patch above                                                               |
+| `shell/*.sh`                      | `shell/*.sh` (unchanged)                                           | not under chezmoi; sourced from `.zshrc` via `$DOTFILES`                                          |
+| `git/.gitconfig`                  | `dot_gitconfig.tmpl`                                               | templated; absorbs `.gituserconfig`                                                               |
+| `git/.gitattributes`              | `dot_gitattributes`                                                | rename                                                                                            |
+| `git/.gitignore`                  | `dot_gitignore`                                                    | rename                                                                                            |
+| `git/.gituserconfig`              | gone — folded into chezmoi data via init prompts                   | per-machine answers stored in `~/.config/chezmoi/chezmoi.toml` (gitignored by chezmoi by default) |
+| `tmux/.tmux.conf`                 | `dot_tmux.conf`                                                    | rename; add `source-file` line                                                                    |
+| seebi tmux colors                 | `tmux/tmuxcolors-dark.conf` (vendored)                             | ignored by chezmoi                                                                                |
+| `.inputrc`                        | `dot_inputrc`                                                      | rename                                                                                            |
+| `emacs/init.el`                   | `dot_emacs.d/init.el`                                              | newly managed; refresh package archives (drop marmalade, https melpa)                             |
+| (live) `~/.config/ghostty/config` | `dot_config/ghostty/config`                                        | newly managed; primary terminal (cmux/Ghostty), `iTerm2 Solarized Dark` theme                     |
+| `starship/starship.toml`          | `dot_config/starship.toml`                                         | path mirrors target                                                                               |
+| seebi dircolors                   | `shell/dircolors.ansi-universal` (vendored)                        | ignored                                                                                           |
+| `mise/fresh.toml`                 | `dot_config/mise/conf.d/fresh.toml`                                | path mirrors target                                                                               |
+| `mise/config.toml`                | `dot_config/mise/config.toml.tmpl`                                 | templated                                                                                         |
+| `mise/config.local.toml`          | `dot_config/mise/config.local.toml.tmpl`                           | templated                                                                                         |
+| `install.sh`                      | `install.sh` (root); `~/bin/dotfiles` via `bin/symlink_dotfiles`   | script not managed; the ~/bin symlink is                                                          |
+| `bin/symlinks/subl,subl3`         | `bin/symlink_subl.tmpl` → `~/bin/subl`; drop `subl3`               | chezmoi `symlink_`, darwin-gated via `.chezmoiignore`                                             |
+| `bin/crossOriginChrome.sh`        | `bin/executable_cross_origin_chrome` → `~/bin/cross_origin_chrome` | renamed snake_case, no ext; chezmoi `executable_` sets +x                                         |
+| iTerm2 integration curl           | `run_once_before_10-iterm2-shell-integration.sh.tmpl`              | chezmoi tracks state                                                                              |
 
 ## Cut-over plan
 
@@ -295,7 +296,7 @@ Gone vs current `install.sh`:
 3. Create `.chezmoiignore`, `dot_config/chezmoi/chezmoi.toml.tmpl`.
 4. Rename and (where needed) templatize files per the layout. One commit per cluster (git, mise, shell-roots, config dir, scripts) keeps the diff reviewable.
 5. Rewrite `install.sh`.
-6. On a clean profile *or* after backing up `~`'s currently-symlinked files: run `./install.sh`, then `chezmoi status` should report empty.
+6. On a clean profile _or_ after backing up `~`'s currently-symlinked files: run `./install.sh`, then `chezmoi status` should report empty.
 7. Delete `.freshrc`. Drop fresh references from `install.sh` and `Brewfile`. Remove `~/.fresh/` (manual on the dev machine).
 8. Update `2026_REFRESH.md`: replace the Stow plan with chezmoi reality. Move from "Future Plans" to "What Changed."
 
@@ -304,12 +305,12 @@ Gone vs current `install.sh`:
 _(Vendoring resolved — now step 2 of the cut-over plan. The `config.local.toml` comment fix is committed on this branch — `b5ab690`.)_
 
 1. **`emacs/init.el`** — ✅ **include.** Migrate to `dot_emacs.d/init.el` (technomancy `emacs-starter-kit` lineage: `better-defaults`, `paredit`, `magit`, `smex`). Refresh the package archives during the move: drop the dead `marmalade-repo`, switch `melpa-stable` to `https`, add `melpa`. Wasn't in `.freshrc`, so this newly puts it under management.
-2. **`iterm2-preferences/`** — 🅿️ **punt prefs management; Ghostty is now primary.** Ghostty's config is plain text (`~/.config/ghostty/config`) and joins chezmoi cleanly (now in the layout as `dot_config/ghostty/config`). iTerm2 stays *installed* as a secondary for the one thing Ghostty/cmux can't do yet — **`tmux -CC` control mode**, especially over remote ssh. Its other historical edge, the **hotkey/Quake window**, is already covered by Ghostty's `global:opt+`=toggle_quick_terminal`. Don't wire up iTerm2 prefs now; keep the how-to in case it earns a permanent seat:
+2. **`iterm2-preferences/`** — 🅿️ **punt prefs management; Ghostty is now primary.** Ghostty's config is plain text (`~/.config/ghostty/config`) and joins chezmoi cleanly (now in the layout as `dot_config/ghostty/config`). iTerm2 stays _installed_ as a secondary for the one thing Ghostty/cmux can't do yet — **`tmux -CC` control mode**, especially over remote ssh. Its other historical edge, the **hotkey/Quake window**, is already covered by Ghostty's `global:opt+`=toggle_quick_terminal`. Don't wire up iTerm2 prefs now; keep the how-to in case it earns a permanent seat:
    - Native "custom preferences folder": `defaults write com.googlecode.iterm2 PrefsCustomFolder -string "$HOME/.dotfiles/iterm2-preferences"` + `LoadPrefsFromCustomFolder -bool true`. iTerm2 then reads/writes `com.googlecode.iterm2.plist` in that folder; commit it. Loosen `iterm2-preferences/.gitignore` (currently `*` / `!.gitignore`) to allow the plist.
    - Prefer that over chezmoi-managing the plist directly — iTerm2 rewrites it constantly; chezmoi would just leave the dir alone.
    - Watch for `tmux -CC` support landing in Ghostty/cmux — that's the trigger to retire iTerm2 entirely.
-3. **`bin/symlinks/subl,subl3`** — ✅ **keep, simplified, chezmoi-managed.** *Not* a `mise link` candidate (that's for runtime versions, not app CLIs). chezmoi owns `~/bin` now, so a `symlink_subl.tmpl` entry creates `~/bin/subl` → `/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl`, OS-gated via `.chezmoiignore` (`{{ if ne .chezmoi.os "darwin" }}bin/subl{{ end }}`); drop the `subl→subl3` indirection.
-4. **`bin/crossOriginChrome.sh`** — ✅ **keep, modernized, chezmoi-managed.** Old (~2013) `--disable-web-security` launcher, verified still valid as of 2026. Reworked: `CHROME_BIN` override, `mktemp -d` profile (now flagged *required* — Chrome v73+ ignores `--disable-web-security` without a non-default `--user-data-dir`), security note. shellcheck-clean. Renamed snake_case / no extension; chezmoi `bin/executable_cross_origin_chrome` lands it at `~/bin/cross_origin_chrome` (+x, on PATH). **The live file is already renamed to `bin/cross_origin_chrome`; the `executable_` prefix gets added at cut-over (step 4) when chezmoi takes over `~/bin`.**
+3. **`bin/symlinks/subl,subl3`** — ✅ **keep, simplified, chezmoi-managed.** _Not_ a `mise link` candidate (that's for runtime versions, not app CLIs). chezmoi owns `~/bin` now, so a `symlink_subl.tmpl` entry creates `~/bin/subl` → `/Applications/Sublime Text.app/Contents/SharedSupport/bin/subl`, OS-gated via `.chezmoiignore` (`{{ if ne .chezmoi.os "darwin" }}bin/subl{{ end }}`); drop the `subl→subl3` indirection.
+4. **`bin/crossOriginChrome.sh`** — ✅ **keep, modernized, chezmoi-managed.** Old (~2013) `--disable-web-security` launcher, verified still valid as of 2026. Reworked: `CHROME_BIN` override, `mktemp -d` profile (now flagged _required_ — Chrome v73+ ignores `--disable-web-security` without a non-default `--user-data-dir`), security note. shellcheck-clean. Renamed snake_case / no extension; chezmoi `bin/executable_cross_origin_chrome` lands it at `~/bin/cross_origin_chrome` (+x, on PATH). **The live file is already renamed to `bin/cross_origin_chrome`; the `executable_` prefix gets added at cut-over (step 4) when chezmoi takes over `~/bin`.**
 5. **Per-machine zsh overrides** — keep `~/.extra` (sourced by `.zshrc`, gitignored). Could move to chezmoi templates later if `.extra` gets crowded.
 6. **The init prompts** — `name`, `email`, `work`, `machine` is the starting set. Add others lazily as needs surface.
 
@@ -319,7 +320,7 @@ _(Vendoring resolved — now step 2 of the cut-over plan. The `config.local.toml
 
 [GNU Stow](https://www.gnu.org/software/stow/manual/stow.html) is the boring, ubiquitous, well-documented option. For most of this conversation it was the right answer: minimum-viable symlink farm, every dotfiles blog post on the internet assumes its layout, ~5 commands and a one-paragraph mental model.
 
-We're picking chezmoi over it because the *actual recurring pain* in this repo is per-machine state (mise `config.local.toml`, git `.gituserconfig`, the future "work vs personal" split). Stow + `install.sh` glue handles those manually; chezmoi templates handle them natively. Once you accept that constraint, chezmoi's bigger surface area starts paying for itself.
+We're picking chezmoi over it because the _actual recurring pain_ in this repo is per-machine state (mise `config.local.toml`, git `.gituserconfig`, the future "work vs personal" split). Stow + `install.sh` glue handles those manually; chezmoi templates handle them natively. Once you accept that constraint, chezmoi's bigger surface area starts paying for itself.
 
 If the templating dream sours: chezmoi → Stow conversion is a one-time `rename dot_X → .X` plus moving everything into `<pkg>/` wrapper dirs. No data lock-in.
 
@@ -336,7 +337,7 @@ Stow sketch (preserved for posterity): each top-level dir is a package mirroring
 The sketch above was followed cluster-by-cluster, but reality forced several
 corrections (all committed with rationale in their respective commits):
 
-- **`.chezmoiroot` dropped.** Only needed when source state lives in a *subdir*;
+- **`.chezmoiroot` dropped.** Only needed when source state lives in a _subdir_;
   ours is the repo root. Adding it would mis-point chezmoi. (`.chezmoiignore` was
   verified empirically: chezmoi matches slashless patterns at the top level only,
   so `mise` suppresses `~/mise` without touching `~/.config/mise`.)
@@ -351,9 +352,9 @@ corrections (all committed with rationale in their respective commits):
   already there, but `mise use -g` had written it only to the machine-local
   `config.toml`; a clean checkout's bootstrap would have had no chezmoi.
 - **install.sh bootstrap order fixed.** The sketch ran `mise install` (to get
-  chezmoi) *before* `chezmoi apply`, but the mise baseline isn't symlinked until
+  chezmoi) _before_ `chezmoi apply`, but the mise baseline isn't symlinked until
   apply. Corrected to: bootstrap chezmoi via `mise exec chezmoi@latest`, apply,
-  *then* `mise install` the full toolchain.
+  _then_ `mise install` the full toolchain.
 - **emacs: adopted the LIVE `~/.emacs.d/init.el`**, not the repo's `emacs/init.el`.
   The live file was already modern (https melpa, better-defaults, sanityinc theme,
   treesit); the repo copy was the stale technomancy starter-kit. Pushing the repo

--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ chezmoi status           # empty = $HOME matches the repo
 
 Four tools, clear lanes:
 
-| Tool | Owns | Lives in |
-|------|------|----------|
-| **chezmoi** (`mode = symlink`) | dotfiles, templates, per-machine data | repo root (`dot_*`, `private_*`, `*.tmpl`) |
-| **mise** | CLI toolchain (node, rust, go, bun, starship, ripgrep, chezmoi itself, LSP servers…) | `dot_config/mise/conf.d/fresh.toml` (shared) + `config.local.toml` (per-machine) |
-| **uv** | Python interpreters, venvs, one-off scripts (`uv run`); executes mise's `pipx:` tools | declared as `pipx:<pkg>` in `fresh.toml` |
-| **Homebrew** | shells, system PATH replacements, GUI casks, fonts, terminfo, keychain-integrated tools | `Brewfile` (+ `Brewfile.optional`) |
+| Tool                           | Owns                                                                                    | Lives in                                                                         |
+| ------------------------------ | --------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| **chezmoi** (`mode = symlink`) | dotfiles, templates, per-machine data                                                   | repo root (`dot_*`, `private_*`, `*.tmpl`)                                       |
+| **mise**                       | CLI toolchain (node, rust, go, bun, starship, ripgrep, chezmoi itself, LSP servers…)    | `dot_config/mise/conf.d/fresh.toml` (shared) + `config.local.toml` (per-machine) |
+| **uv**                         | Python interpreters, venvs, one-off scripts (`uv run`); executes mise's `pipx:` tools   | declared as `pipx:<pkg>` in `fresh.toml`                                         |
+| **Homebrew**                   | shells, system PATH replacements, GUI casks, fonts, terminfo, keychain-integrated tools | `Brewfile` (+ `Brewfile.optional`)                                               |
 
 ### chezmoi source naming
 
@@ -92,22 +92,22 @@ Intel→Apple-Silicon move (`/usr/local` → `/opt/homebrew`) was overdue.
 
 What changed:
 
-| Old | New | Why |
-|-----|-----|-----|
-| bash + Bash-It | zsh + `shell/*.sh` | macOS default; shell-agnostic helpers |
-| Fresh | **chezmoi** | per-machine templating, no build step, active project |
-| nvm | **mise** | polyglot, fast, no shell-startup penalty |
-| Bash-It themes | **Starship** | cross-shell, fast |
-| fasd | **zoxide** | faster, maintained |
-| hub | **gh** | official GitHub CLI |
-| Python 2 http.server | Python 3 / **uv** | Py2 EOL |
+| Old                  | New                | Why                                                   |
+| -------------------- | ------------------ | ----------------------------------------------------- |
+| bash + Bash-It       | zsh + `shell/*.sh` | macOS default; shell-agnostic helpers                 |
+| Fresh                | **chezmoi**        | per-machine templating, no build step, active project |
+| nvm                  | **mise**           | polyglot, fast, no shell-startup penalty              |
+| Bash-It themes       | **Starship**       | cross-shell, fast                                     |
+| fasd                 | **zoxide**         | faster, maintained                                    |
+| hub                  | **gh**             | official GitHub CLI                                   |
+| Python 2 http.server | Python 3 / **uv**  | Py2 EOL                                               |
 
 Added along the way: `bat`, `fd`, `ripgrep`, `fzf`, `git-delta`. The Brewfile was
 pared to essentials (dropped `boot2docker`/`docker-machine`/`fig`,
 `reattach-to-user-namespace`, discontinued editors, stale `caskroom/*` taps).
 
 **Fresh → chezmoi:** GNU Stow was considered and rejected — the recurring pain
-here is *per-machine state* (mise `config.local.toml`, git identity, future
+here is _per-machine state_ (mise `config.local.toml`, git identity, future
 work/personal split), which chezmoi templates solve natively and Stow does not.
 `tuckr` was evaluated and dropped. Full rationale and cut-over log:
 **[CHEZMOI_MIGRATION.md](./CHEZMOI_MIGRATION.md)**.

--- a/cheatsheets/README.md
+++ b/cheatsheets/README.md
@@ -5,11 +5,11 @@ Source-only: listed in `.chezmoiignore`, never deployed to `$HOME`.
 
 ## Contents
 
-| File | What | Source |
-|------|------|--------|
-| [custom-keybindings.md](custom-keybindings.md) | Every keybinding this config adds (fzf, ghostel, magit, apheleia, grip) | **Generated** from init.el — see below |
+| File                                             | What                                                                                  | Source                                                                                  |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| [custom-keybindings.md](custom-keybindings.md)   | Every keybinding this config adds (fzf, ghostel, magit, apheleia, grip)               | **Generated** from init.el — see below                                                  |
 | [paredit-cheatsheet.svg](paredit-cheatsheet.svg) | Structural editing commands for lisp buffers (paredit is hook-enabled in this config) | [joelittlejohn/paredit-cheatsheet](https://github.com/joelittlejohn/paredit-cheatsheet) |
-| [emacs-fundamentals.md](emacs-fundamentals.md) | Links to the official GNU refcards + crib tables for kill/yank/mark and dired | [gnu.org refcards](https://www.gnu.org/software/emacs/refcards/) |
+| [emacs-fundamentals.md](emacs-fundamentals.md)   | Links to the official GNU refcards + crib tables for kill/yank/mark and dired         | [gnu.org refcards](https://www.gnu.org/software/emacs/refcards/)                        |
 
 ## Paredit at a glance
 

--- a/cheatsheets/custom-keybindings.md
+++ b/cheatsheets/custom-keybindings.md
@@ -13,18 +13,20 @@ emacs --batch -l cheatsheets/generate-custom-keys.el
 (`--check` mode exits non-zero if it's stale: append `-- --check`.)
 
 <!-- BEGIN GENERATED — edit init.el, not this table -->
-| Key | Command | Package | Keymap |
-|-----|---------|---------|--------|
-| <kbd>g</kbd> | `grip-mode` | grip-mode | `markdown-mode-command-map` |
-| <kbd><kbd>C-x</kbd> <kbd>g</kbd></kbd> | `magit-status` | magit | global |
-| <kbd><kbd>C-c</kbd> <kbd>t</kbd></kbd> | `ghostel` | ghostel | global |
-| <kbd><kbd>C-c</kbd> <kbd>z</kbd> <kbd>f</kbd></kbd> | `fzf-find-file` | fzf | global |
-| <kbd><kbd>C-c</kbd> <kbd>z</kbd> <kbd>g</kbd></kbd> | `fzf-git-files` | fzf | global |
-| <kbd><kbd>C-c</kbd> <kbd>z</kbd> <kbd>b</kbd></kbd> | `fzf-switch-buffer` | fzf | global |
-| <kbd><kbd>C-c</kbd> <kbd>z</kbd> <kbd>e</kbd></kbd> | `fzf-recentf` | fzf | global |
-| <kbd><kbd>C-c</kbd> <kbd>z</kbd> <kbd>r</kbd></kbd> | `fzf-grep-dwim` | fzf | global |
-| <kbd><kbd>C-c</kbd> <kbd>z</kbd> <kbd>R</kbd></kbd> | `fzf-grep` | fzf | global |
-| <kbd><kbd>C-c</kbd> <kbd>f</kbd></kbd> | `apheleia-format-buffer` | apheleia | global |
+
+| Key                                                 | Command                  | Package   | Keymap                      |
+| --------------------------------------------------- | ------------------------ | --------- | --------------------------- |
+| <kbd>g</kbd>                                        | `grip-mode`              | grip-mode | `markdown-mode-command-map` |
+| <kbd><kbd>C-x</kbd> <kbd>g</kbd></kbd>              | `magit-status`           | magit     | global                      |
+| <kbd><kbd>C-c</kbd> <kbd>t</kbd></kbd>              | `ghostel`                | ghostel   | global                      |
+| <kbd><kbd>C-c</kbd> <kbd>z</kbd> <kbd>f</kbd></kbd> | `fzf-find-file`          | fzf       | global                      |
+| <kbd><kbd>C-c</kbd> <kbd>z</kbd> <kbd>g</kbd></kbd> | `fzf-git-files`          | fzf       | global                      |
+| <kbd><kbd>C-c</kbd> <kbd>z</kbd> <kbd>b</kbd></kbd> | `fzf-switch-buffer`      | fzf       | global                      |
+| <kbd><kbd>C-c</kbd> <kbd>z</kbd> <kbd>e</kbd></kbd> | `fzf-recentf`            | fzf       | global                      |
+| <kbd><kbd>C-c</kbd> <kbd>z</kbd> <kbd>r</kbd></kbd> | `fzf-grep-dwim`          | fzf       | global                      |
+| <kbd><kbd>C-c</kbd> <kbd>z</kbd> <kbd>R</kbd></kbd> | `fzf-grep`               | fzf       | global                      |
+| <kbd><kbd>C-c</kbd> <kbd>f</kbd></kbd>              | `apheleia-format-buffer` | apheleia  | global                      |
+
 <!-- END GENERATED -->
 
 ## What each package does

--- a/cheatsheets/emacs-fundamentals.md
+++ b/cheatsheets/emacs-fundamentals.md
@@ -9,19 +9,19 @@ Official GNU reference cards — linked, not vendored (they track Emacs releases
 
 ## Mark, kill, yank — the core moves
 
-| Key | Action |
-|-----|--------|
-| <kbd>C-SPC</kbd> | set mark; start selecting a region |
-| <kbd><kbd>C-x</kbd> <kbd>C-x</kbd></kbd> | swap point and mark (see both ends of region) |
-| <kbd><kbd>C-u</kbd> <kbd>C-SPC</kbd></kbd> | jump back to previous mark |
-| <kbd>M-h</kbd> / <kbd><kbd>C-x</kbd> <kbd>h</kbd></kbd> | mark paragraph / whole buffer |
-| <kbd>C-w</kbd> | kill (cut) region |
-| <kbd>M-w</kbd> | copy region to kill ring |
-| <kbd>C-k</kbd> | kill to end of line |
-| <kbd>M-d</kbd> / <kbd>M-DEL</kbd> | kill word forward / backward |
-| <kbd>C-y</kbd> | yank (paste) most recent kill |
-| <kbd>M-y</kbd> | right after <kbd>C-y</kbd>: cycle back through earlier kills |
-| <kbd>C-/</kbd> | undo (also <kbd><kbd>C-x</kbd> <kbd>u</kbd></kbd>) |
+| Key                                                     | Action                                                       |
+| ------------------------------------------------------- | ------------------------------------------------------------ |
+| <kbd>C-SPC</kbd>                                        | set mark; start selecting a region                           |
+| <kbd><kbd>C-x</kbd> <kbd>C-x</kbd></kbd>                | swap point and mark (see both ends of region)                |
+| <kbd><kbd>C-u</kbd> <kbd>C-SPC</kbd></kbd>              | jump back to previous mark                                   |
+| <kbd>M-h</kbd> / <kbd><kbd>C-x</kbd> <kbd>h</kbd></kbd> | mark paragraph / whole buffer                                |
+| <kbd>C-w</kbd>                                          | kill (cut) region                                            |
+| <kbd>M-w</kbd>                                          | copy region to kill ring                                     |
+| <kbd>C-k</kbd>                                          | kill to end of line                                          |
+| <kbd>M-d</kbd> / <kbd>M-DEL</kbd>                       | kill word forward / backward                                 |
+| <kbd>C-y</kbd>                                          | yank (paste) most recent kill                                |
+| <kbd>M-y</kbd>                                          | right after <kbd>C-y</kbd>: cycle back through earlier kills |
+| <kbd>C-/</kbd>                                          | undo (also <kbd><kbd>C-x</kbd> <kbd>u</kbd></kbd>)           |
 
 Everything killed lands on the **kill ring** — <kbd>C-y</kbd> then repeated <kbd>M-y</kbd> walks the whole history, so "clipboard" is plural in Emacs.
 
@@ -29,17 +29,17 @@ Everything killed lands on the **kill ring** — <kbd>C-y</kbd> then repeated <k
 
 <kbd><kbd>C-x</kbd> <kbd>d</kbd></kbd> (or visit any directory) opens dired. Inside the buffer:
 
-| Key | Action |
-|-----|--------|
-| <kbd>RET</kbd> / <kbd>o</kbd> | visit file (same / other window) |
-| <kbd>^</kbd> | up to parent directory |
-| <kbd>g</kbd> | refresh listing |
-| <kbd>m</kbd> / <kbd>u</kbd> / <kbd>U</kbd> | mark file / unmark / unmark all |
-| <kbd><kbd>%</kbd> <kbd>m</kbd></kbd> | mark files matching regexp |
-| <kbd>d</kbd> then <kbd>x</kbd> | flag for deletion, then execute flags |
-| <kbd>C</kbd> / <kbd>R</kbd> | copy / rename-or-move (marked files or file at point) |
-| <kbd>+</kbd> | create directory |
-| <kbd>!</kbd> / <kbd>&</kbd> | run shell command on file(s) (sync / async) |
-| <kbd>q</kbd> | quit dired buffer |
+| Key                                        | Action                                                |
+| ------------------------------------------ | ----------------------------------------------------- |
+| <kbd>RET</kbd> / <kbd>o</kbd>              | visit file (same / other window)                      |
+| <kbd>^</kbd>                               | up to parent directory                                |
+| <kbd>g</kbd>                               | refresh listing                                       |
+| <kbd>m</kbd> / <kbd>u</kbd> / <kbd>U</kbd> | mark file / unmark / unmark all                       |
+| <kbd><kbd>%</kbd> <kbd>m</kbd></kbd>       | mark files matching regexp                            |
+| <kbd>d</kbd> then <kbd>x</kbd>             | flag for deletion, then execute flags                 |
+| <kbd>C</kbd> / <kbd>R</kbd>                | copy / rename-or-move (marked files or file at point) |
+| <kbd>+</kbd>                               | create directory                                      |
+| <kbd>!</kbd> / <kbd>&</kbd>                | run shell command on file(s) (sync / async)           |
+| <kbd>q</kbd>                               | quit dired buffer                                     |
 
 Operations act on the **marked** files if any, else the file at point — the <kbd>m</kbd>-then-<kbd>C</kbd>/<kbd>R</kbd>/<kbd>!</kbd> pattern is the batch workflow.

--- a/dot_config/mise/conf.d/fresh.toml
+++ b/dot_config/mise/conf.d/fresh.toml
@@ -82,7 +82,8 @@ chezmoi = "latest"
 marksman                                = "latest" # Markdown LSP
 "pipx:grip"                             = "latest" # GitHub-accurate markdown preview (Emacs grip-mode)
 # Formatters for apheleia (format-on-save off by default; C-c f formats once):
-prettier = "latest" # TS / JSON / YAML / Markdown
+prettier = "latest" # TS / JSON / YAML
+oxfmt    = "latest" # Markdown (npm:oxfmt) — Rust-based; delegates .md to prettier
 shfmt    = "latest" # shell
 taplo    = "latest" # TOML
 # rust-analyzer + rustfmt ship with the rust toolchain. If rust-analyzer is

--- a/dot_config/mise/conf.d/fresh.toml
+++ b/dot_config/mise/conf.d/fresh.toml
@@ -16,7 +16,7 @@ idiomatic_version_file_enable_tools = ["node"]
 credential_command = "gh auth token"
 
 [settings.pipx]
-uvx = true  # "pipx:<pkg>" installs via `uv tool`, no pipx binary needed (default when uv present)
+uvx = true # "pipx:<pkg>" installs via `uv tool`, no pipx binary needed (default when uv present)
 
 [settings.python]
 uv_venv_auto = true
@@ -25,7 +25,7 @@ uv_venv_auto = true
 # Languages
 bun  = "latest"
 go   = "latest"
-node = "lts"  # system default only; projects override via .nvmrc / .node-version / mise.toml
+node = "lts"    # system default only; projects override via .nvmrc / .node-version / mise.toml
 rust = "latest"
 
 # Python: uv owns interpreters, venvs, and `uv run` scripts. CLI tools are "pipx:<pkg>".
@@ -43,7 +43,7 @@ yazi    = "latest"
 # tree: not in mise registry under that short name — left in Brewfile
 
 # Git
-delta   = "latest"  # git-delta
+delta   = "latest" # git-delta
 gh      = "latest"
 lazygit = "latest"
 # tig: not in mise registry under that short name — left in Brewfile
@@ -56,11 +56,11 @@ starship = "latest"
 
 # AI coding agents
 "aqua:openai/codex" = "latest"
-opencode = "latest"  # anomalyco/opencode
+opencode            = "latest" # anomalyco/opencode
 # rtk: always on PATH for explicit `rtk <cmd>` use. Whether it *also* rewrites
 # Bash commands automatically is a per-machine toggle, off until asked for:
 #   mise run rtk:hook / rtk:unhook / rtk:hook:status     (see 2026_REFRESH.md)
-rtk      = "latest"  # aqua:rtk-ai/rtk — token-optimizing CLI proxy.
+rtk = "latest" # aqua:rtk-ai/rtk — token-optimizing CLI proxy.
 
 # Dotfiles management — must be in the committed baseline so a fresh machine's
 # install.sh (mise install -> chezmoi init) can bootstrap. (Previously chezmoi
@@ -74,17 +74,17 @@ chezmoi = "latest"
 # on first file open. Only language servers + formatters belong in mise.
 # NOTE: this installs fleet-wide via the shared baseline. If you'd rather keep
 # LSP servers off headless boxes, move this block to config.local.toml.
-"npm:typescript-language-server"        = "latest"  # TS / JS / TSX
-"npm:yaml-language-server"              = "latest"  # YAML
-"npm:vscode-langservers-extracted"      = "latest"  # JSON / CSS / HTML / ESLint
-"npm:bash-language-server"              = "latest"  # Bash / sh
-"npm:dockerfile-language-server-nodejs" = "latest"  # Dockerfile
-marksman = "latest"  # Markdown LSP
-"pipx:grip" = "latest"  # GitHub-accurate markdown preview (Emacs grip-mode)
+"npm:typescript-language-server"        = "latest" # TS / JS / TSX
+"npm:yaml-language-server"              = "latest" # YAML
+"npm:vscode-langservers-extracted"      = "latest" # JSON / CSS / HTML / ESLint
+"npm:bash-language-server"              = "latest" # Bash / sh
+"npm:dockerfile-language-server-nodejs" = "latest" # Dockerfile
+marksman                                = "latest" # Markdown LSP
+"pipx:grip"                             = "latest" # GitHub-accurate markdown preview (Emacs grip-mode)
 # Formatters for apheleia (format-on-save off by default; C-c f formats once):
-prettier = "latest"  # TS / JSON / YAML / Markdown
-shfmt    = "latest"  # shell
-taplo    = "latest"  # TOML
+prettier = "latest" # TS / JSON / YAML / Markdown
+shfmt    = "latest" # shell
+taplo    = "latest" # TOML
 # rust-analyzer + rustfmt ship with the rust toolchain. If rust-analyzer is
 # absent:  rustup component add rust-analyzer rustfmt
 
@@ -105,16 +105,16 @@ taplo    = "latest"  # TOML
 
 [tasks."rtk:hook"]
 description = "Enable rtk's Claude Code hook (allowlisted commands get rewritten)"
-run = '"$HOME/bin/rtk-hook" enable'
+run         = '"$HOME/bin/rtk-hook" enable'
 
 [tasks."rtk:unhook"]
 description = "Disable it — rtk stays on PATH, nothing is rewritten automatically"
-run = '"$HOME/bin/rtk-hook" disable'
+run         = '"$HOME/bin/rtk-hook" disable'
 
 [tasks."rtk:hook:status"]
 description = "Show whether rtk's hook is wired, and flag any drift"
-run = '"$HOME/bin/rtk-hook" status'
+run         = '"$HOME/bin/rtk-hook" status'
 
 [tasks."rtk:uninstall"]
 description = "Remove rtk entirely, wiring included (dry run; pass -- --yes)"
-run = '"$HOME/bin/rtk-uninstall"'
+run         = '"$HOME/bin/rtk-uninstall"'

--- a/dot_config/starship.toml
+++ b/dot_config/starship.toml
@@ -3,23 +3,23 @@ truncation_length = 0
 
 [time]
 disabled = false
-style = "bold green"
+style    = "bold green"
 
 [username]
 show_always = true
-format = "[$user]($style)@"
-style_user = "blue"
+format      = "[$user]($style)@"
+style_user  = "blue"
 
 
 [hostname]
 ssh_only = false
-trim_at = ""
-style = "blue"
+trim_at  = ""
+style    = "blue"
 
 [character]
 success_symbol = "[λ](bold green)"
 error_symbol = "[λ](bold red)"
-format	= """
+format = """
 
  $symbol 
 """

--- a/emacs.md
+++ b/emacs.md
@@ -22,9 +22,10 @@ On a fresh machine, after `chezmoi apply` + `mise install`:
 ## What's installed and why
 
 ### Foundation
+
 - **use-package** (built-in, Emacs 29+) — declarative, self-installing config
   (`use-package-always-ensure t`).
-- **better-defaults** — sane editing baseline. *Note:* now pulled from MELPA;
+- **better-defaults** — sane editing baseline. _Note:_ now pulled from MELPA;
   was previously a manual clone under `~/.emacs.d/better-defaults`.
 - Built-ins enabled: `which-key-mode` (Emacs 30 built-in), `savehist-mode`,
   `recentf-mode`, `electric-pair-mode`, `display-line-numbers-mode` in prog
@@ -33,7 +34,8 @@ On a fresh machine, after `chezmoi apply` + `mise install`:
   never collide with the chezmoi-managed (symlinked) `init.el`.
 
 ### PATH / environment
-- **exec-path-from-shell** (`:when` GUI on macOS) — imports PATH from a *login*
+
+- **exec-path-from-shell** (`:when` GUI on macOS) — imports PATH from a _login_
   shell (`-l`, which sources `~/.zprofile`) so a Dock/Spotlight-launched
   `Emacs.app` can find the mise shims (language servers). No-op in terminal /
   headless sessions, which already inherit PATH. The shims PATH itself lives in
@@ -41,37 +43,44 @@ On a fresh machine, after `chezmoi apply` + `mise install`:
   interactive `~/.zshrc`.
 
 ### Appearance
+
 - **color-theme-sanityinc-solarized** — `sanityinc-solarized-dark`
   (self-installing so a fresh machine reproduces it).
 - Font: `Operator Mono SSm Book-11`.
 
 ### Syntax highlighting — tree-sitter
+
 - **treesit-auto** — installs grammars on demand and remaps file types to the
   built-in `*-ts-mode` major modes (ts/tsx/js/json/yaml/toml/rust/bash/
   dockerfile/css/html). Emacs 30 ships the modes; grammars are downloaded
   per-machine, not committed.
 
 ### Markdown
+
 - **markdown-mode** — `.md`/`README.md` open in `gfm-mode` (GitHub-flavored);
   `markdown-command` = `pandoc`; fenced code blocks highlight natively.
 - **grip-mode** — GitHub-accurate live preview (needs `grip`, in the mise
   baseline as `pipx:grip`). Bound to `g` in the markdown command map.
 
 ### LSP — Eglot (built-in)
+
 `eglot-ensure` is hooked into: `typescript-ts-mode`, `tsx-ts-mode`,
 `js-ts-mode`, `rust-ts-mode`, `yaml-ts-mode`, `json-ts-mode`, `bash-ts-mode`,
 `dockerfile-ts-mode`. Servers live in mise (see below).
 
 ### Completion
+
 - **corfu** — in-buffer completion popup (`corfu-auto`, `corfu-cycle`).
 - **cape** — completion sources (`cape-file`, `cape-dabbrev`).
 - **vertico** + **marginalia** + **orderless** — minibuffer completion,
   annotations, and fuzzy matching for command/file/project navigation.
 
 ### Git
+
 - **magit** — `C-x g`.
 
 ### Terminal — ghostel
+
 - **ghostel** ([dakra/ghostel](https://github.com/dakra/ghostel)) — terminal
   emulator backed by libghostty-vt (Ghostty's VT engine). A prebuilt native
   module auto-downloads on first `M-x ghostel`; no toolchain/compile step like
@@ -86,6 +95,7 @@ On a fresh machine, after `chezmoi apply` + `mise install`:
   - `C-c t` — open a ghostel terminal.
 
 ### Fuzzy finding — fzf.el
+
 - **fzf.el** ([bling/fzf.el](https://github.com/bling/fzf.el)) — runs the
   terminal `fzf` in a popup term buffer. Complements the minibuffer stack
   (vertico/orderless); shines for fast git-tracked file jumps and whole-repo
@@ -93,30 +103,34 @@ On a fresh machine, after `chezmoi apply` + `mise install`:
   use `rg` (`fzf/grep-command` = `rg --no-heading -nH --color=always`), also in
   the baseline.
 
-  | Key | Command | Action |
-  |-----|---------|--------|
-  | `C-c z f` | `fzf-find-file` | files under `default-directory` |
-  | `C-c z g` | `fzf-git-files` | files tracked in the git repo |
-  | `C-c z b` | `fzf-switch-buffer` | switch buffer |
-  | `C-c z e` | `fzf-recentf` | recent files |
-  | `C-c z r` | `fzf-grep-dwim` | ripgrep content, seeded from symbol at point |
-  | `C-c z R` | `fzf-grep` | ripgrep content, prompt for pattern |
+  | Key       | Command             | Action                                       |
+  | --------- | ------------------- | -------------------------------------------- |
+  | `C-c z f` | `fzf-find-file`     | files under `default-directory`              |
+  | `C-c z g` | `fzf-git-files`     | files tracked in the git repo                |
+  | `C-c z b` | `fzf-switch-buffer` | switch buffer                                |
+  | `C-c z e` | `fzf-recentf`       | recent files                                 |
+  | `C-c z r` | `fzf-grep-dwim`     | ripgrep content, seeded from symbol at point |
+  | `C-c z R` | `fzf-grep`          | ripgrep content, prompt for pattern          |
 
 ### Editing polish
+
 - **rainbow-delimiters** — colored paren nesting in prog buffers.
 - **paredit** — structural editing in lisp buffers (emacs-lisp, lisp-interaction,
   lisp, ielm). `electric-pair-local-mode` is disabled there so paredit owns
   paren insertion.
 
 ### Formatting — apheleia (opt-in)
+
 Installed but **format-on-save is OFF by default**.
+
 - `C-c f` — format the current buffer once (`apheleia-format-buffer`).
 - `M-x apheleia-global-mode` — toggle format-on-save for the session.
 
-Formatters (in mise): `prettier` (TS/JSON/YAML/MD), `shfmt` (shell),
-`taplo` (TOML), `rustfmt` (rust toolchain).
+Formatters (in mise): `prettier` (TS/JSON/YAML), `oxfmt` (Markdown),
+`shfmt` (shell), `taplo` (TOML), `rustfmt` (rust toolchain).
 
 ### chezmoi
+
 - **chezmoi.el** — edit/diff/apply chezmoi-managed files from inside Emacs
   (knows the `private_dot_emacs.d/init.el` → `~/.emacs.d/init.el` mapping).
 
@@ -126,17 +140,18 @@ Language servers (`npm:` backend) and formatters (registry short names) install
 fleet-wide via the shared baseline. To keep them off headless boxes, move the
 "Emacs dev tooling" block to `~/.config/mise/config.local.toml`.
 
-| Tool | mise entry | Backs |
-|------|-----------|-------|
-| typescript-language-server | `npm:typescript-language-server` | TS/JS/TSX (Eglot) |
-| yaml-language-server | `npm:yaml-language-server` | YAML (Eglot) |
-| vscode-langservers-extracted | `npm:vscode-langservers-extracted` | JSON/CSS/HTML (Eglot) |
-| bash-language-server | `npm:bash-language-server` | Bash (Eglot) |
-| dockerfile-language-server-nodejs | `npm:dockerfile-language-server-nodejs` | Dockerfile (Eglot) |
-| marksman | `marksman` | Markdown LSP |
-| prettier | `prettier` | format TS/JSON/YAML/MD |
-| shfmt | `shfmt` | format shell |
-| taplo | `taplo` | format TOML |
+| Tool                              | mise entry                              | Backs                 |
+| --------------------------------- | --------------------------------------- | --------------------- |
+| typescript-language-server        | `npm:typescript-language-server`        | TS/JS/TSX (Eglot)     |
+| yaml-language-server              | `npm:yaml-language-server`              | YAML (Eglot)          |
+| vscode-langservers-extracted      | `npm:vscode-langservers-extracted`      | JSON/CSS/HTML (Eglot) |
+| bash-language-server              | `npm:bash-language-server`              | Bash (Eglot)          |
+| dockerfile-language-server-nodejs | `npm:dockerfile-language-server-nodejs` | Dockerfile (Eglot)    |
+| marksman                          | `marksman`                              | Markdown LSP          |
+| prettier                          | `prettier`                              | format TS/JSON/YAML   |
+| oxfmt                             | `oxfmt`                                 | format Markdown       |
+| shfmt                             | `shfmt`                                 | format shell          |
+| taplo                             | `taplo`                                 | format TOML           |
 
 rust-analyzer + rustfmt come with the rust toolchain. If rust-analyzer is
 missing: `rustup component add rust-analyzer rustfmt`.
@@ -163,14 +178,14 @@ dired + GNU refcard links). Index: [cheatsheets/README.md](cheatsheets/README.md
 Neither dotfiles nor silicon-grove uses Clojure today, so this layer is staged
 but inert. The pieces:
 
-| Piece | Package / tool | Role |
-|-------|----------------|------|
-| Major mode | `clojure-ts-mode` | tree-sitter clj/cljs/edn |
-| REPL / IDE | `cider` | nREPL REPL, eval-in-buffer, debugger; drives cljs via shadow-cljs/figwheel |
-| Structural edit | `paredit` | already configured — extend hook to clojure modes |
-| Linting | `clj-kondo` + `flycheck-clj-kondo` | static analysis |
-| Refactor | `clj-refactor` | optional |
-| LSP | `clojure-lsp` via Eglot | nav/completion (coexists with CIDER) |
+| Piece           | Package / tool                     | Role                                                                       |
+| --------------- | ---------------------------------- | -------------------------------------------------------------------------- |
+| Major mode      | `clojure-ts-mode`                  | tree-sitter clj/cljs/edn                                                   |
+| REPL / IDE      | `cider`                            | nREPL REPL, eval-in-buffer, debugger; drives cljs via shadow-cljs/figwheel |
+| Structural edit | `paredit`                          | already configured — extend hook to clojure modes                          |
+| Linting         | `clj-kondo` + `flycheck-clj-kondo` | static analysis                                                            |
+| Refactor        | `clj-refactor`                     | optional                                                                   |
+| LSP             | `clojure-lsp` via Eglot            | nav/completion (coexists with CIDER)                                       |
 
 **Coexistence:** run CIDER for the live REPL and clojure-lsp (Eglot) for
 navigation/completion — the standard combo. For ClojureScript, CIDER connects
@@ -208,6 +223,6 @@ clj-kondo = "latest"  # linter
 
 ### Naming footnote
 
-The **marginalia** in this config is the *minibuffer-annotations* package
+The **marginalia** in this config is the _minibuffer-annotations_ package
 (~2021). It is **not** the older Clojure **Marginalia** literate-docs generator
 (gdeer81) of around a decade ago — same name, different tool.

--- a/private_bin/executable_cross_origin_chrome
+++ b/private_bin/executable_cross_origin_chrome
@@ -22,7 +22,7 @@ CHROME_BIN="${CHROME_BIN:-/Applications/Google Chrome.app/Contents/MacOS/Google 
 USER_DATA_DIR="$(mktemp -d "${TMPDIR:-/tmp}/cross_origin_chrome.XXXXXX")"
 
 (
-	"$CHROME_BIN" --disable-web-security --user-data-dir="$USER_DATA_DIR" > /dev/null 2>&1 &
+	"$CHROME_BIN" --disable-web-security --user-data-dir="$USER_DATA_DIR" >/dev/null 2>&1 &
 	chrome_process_id=$!
 	wait "$chrome_process_id"
 	rm -rf "$USER_DATA_DIR"

--- a/shell/aliases.sh
+++ b/shell/aliases.sh
@@ -7,7 +7,7 @@
 if command -v gls &>/dev/null; then
     alias ls='gls --color=auto -p -F'
 else
-    alias ls='ls -GFh'  # macOS fallback
+    alias ls='ls -GFh' # macOS fallback
 fi
 alias la='ls -A'
 alias ll='ls -lh'

--- a/shell/exports.sh
+++ b/shell/exports.sh
@@ -8,16 +8,16 @@ export HISTSIZE=100000
 export SAVEHIST=100000
 export HISTFILE=~/.zsh_history
 
-setopt EXTENDED_HISTORY          # Timestamp format :start:elapsed:command
-setopt INC_APPEND_HISTORY        # Write immediately, not on exit
-setopt SHARE_HISTORY             # Share between sessions
-setopt HIST_EXPIRE_DUPS_FIRST    # Expire dupes first
-setopt HIST_IGNORE_DUPS          # Don't record immediate dupes
-setopt HIST_IGNORE_ALL_DUPS      # Remove older dupe entries
-setopt HIST_FIND_NO_DUPS         # Don't show dupes when searching
-setopt HIST_IGNORE_SPACE         # Don't record entries starting with space
-setopt HIST_SAVE_NO_DUPS         # Don't write dupes to file
-setopt HIST_REDUCE_BLANKS        # Remove extra blanks
+setopt EXTENDED_HISTORY       # Timestamp format :start:elapsed:command
+setopt INC_APPEND_HISTORY     # Write immediately, not on exit
+setopt SHARE_HISTORY          # Share between sessions
+setopt HIST_EXPIRE_DUPS_FIRST # Expire dupes first
+setopt HIST_IGNORE_DUPS       # Don't record immediate dupes
+setopt HIST_IGNORE_ALL_DUPS   # Remove older dupe entries
+setopt HIST_FIND_NO_DUPS      # Don't show dupes when searching
+setopt HIST_IGNORE_SPACE      # Don't record entries starting with space
+setopt HIST_SAVE_NO_DUPS      # Don't write dupes to file
+setopt HIST_REDUCE_BLANKS     # Remove extra blanks
 
 # ============================================================
 # Editor

--- a/shell/functions.sh
+++ b/shell/functions.sh
@@ -61,7 +61,10 @@ gf() {
 # ============================================================
 if [[ "$TERM_PROGRAM" == 'iTerm.app' ]]; then
     nametab() {
-        [[ -z "$1" ]] && { echo "Usage: nametab <name>"; return 1; }
+        [[ -z "$1" ]] && {
+            echo "Usage: nametab <name>"
+            return 1
+        }
         echo -ne "\033]0;$*\007"
     }
 fi
@@ -94,7 +97,7 @@ eightbit() {
                 printf("%c",c)};
             c=int(c);
             while(c!=128) { c<128?c++:c--; printf("%c",c)}}}' |
-    sox -t raw -r 64k -c 1 -e unsigned -b 8 - -d
+        sox -t raw -r 64k -c 1 -e unsigned -b 8 - -d
 }
 
 # ============================================================


### PR DESCRIPTION
`taplo fmt --check` and `shfmt -d` both fail on `main`. This fixes the drift by
teaching the formatters the style the repo already uses, rather than reflowing
files to formatter defaults.

## The `align_entries` decision

`dot_config/mise/conf.d/fresh.toml` hand-aligns its `=` columns:

```toml
bat     = "latest"
fd      = "latest"
ripgrep = "latest"
```

taplo's default is `align_entries = false`, which collapses all of that to
single spaces — a ~60-line diff that destroys an intentional, repo-wide style
choice. So the new `.taplo.toml` sets `align_entries = true` (plus
`align_comments = true`, taplo's default, written out explicitly next to it).
With that config, **every hand-aligned block in `fresh.toml` survives
byte-for-byte.**

### What taplo still insists on, and could not be configured away

taplo hard-codes **exactly one space** before a trailing `#`. The repo's
`key = value  # why` two-space convention becomes `key = value # why`. There is
no formatter option for this — I checked taplo 0.10.0's `[formatting]` schema
and tested `align_comments = false`, which changes only the multi-line
alignment, not the single-space normalization.

That accounts for essentially the entire residual diff in `fresh.toml`, plus
taplo extending alignment across two blocks the author had left ragged
(`opencode`/`"aqua:openai/codex"`, and `marksman`/`"pipx:grip"` joining the
`npm:*` block). **Worth a look — if the two-space form matters more than
`taplo fmt --check` passing, the alternative is to not run taplo on this file
at all.**

## The `.editorconfig` decision

shfmt reads `.editorconfig` when given no `-i` flag. The repo has two indent
dialects and I did **not** unify them:

- `private_bin/*` — tab-indented (shfmt's default)
- `install.sh`, `shell/*.sh` — 4-space

`.editorconfig` records both, so a bare `shfmt -d` and Emacs/apheleia agree.
`dot_zshrc` is excluded from shfmt entirely: it uses zsh parameter-expansion
flags that shfmt cannot parse (`dot_zshrc:31:5: parameter expansion flags are a
zsh feature`).

## Checks that now pass

```
$ taplo fmt --check
TAPLO EXIT=0        # 4 files: fresh.toml, starship.toml, rtk-config.toml, .taplo.toml

$ shfmt -d install.sh run_after_20-claude-rtk-hook.sh \
    private_bin/executable_cross_origin_chrome private_bin/executable_rtk-hook \
    private_bin/executable_rtk-uninstall shell/*.sh dot_zprofile
SHFMT EXIT=0

$ zsh -n shell/exports.sh shell/aliases.sh shell/functions.sh   # OK
$ bash -n private_bin/executable_cross_origin_chrome            # OK
```

Actual content fixes were all small:

| File | Fix |
|---|---|
| `dot_config/starship.toml` | literal tab in `format\t= """` |
| `private_bin/executable_cross_origin_chrome` | `> /dev/null` → `>/dev/null` (matches the other 20 uses in the repo) |
| `shell/exports.sh` | `setopt` trailing-comment column re-aligned tighter |
| `shell/functions.sh` | `&& { echo …; return 1; }` expanded; `sox` pipe continuation indent |
| `shell/aliases.sh` | trailing-comment spacing |

## Deliberately NOT changed

- **prettier on the 7 markdown files.** All 7 fail `prettier --check`, but
  nothing in this repo configures prettier for markdown — it is installed only
  as an apheleia formatter for the Emacs setup. Applying it wants ~800 lines of
  table re-padding (`| Tool | Owns |` → fully padded columns) plus `*em*` →
  `_em_` across `README.md` (~50 lines), `CHEZMOI_MIGRATION.md` (80),
  `emacs.md` (56), and the cheatsheets. That fights the author's evident
  compact-table style, so it is left for a separate decision. **Ask-worthy.**
- **`.tmpl` files.** Formatting chezmoi templates risks the template syntax.
  Conveniently, taplo's `**/*.toml` include glob does not match `*.toml.tmpl`,
  and the one shell template (`run_once_before_10-iterm2-shell-integration.sh.tmpl`)
  has no indentation to reformat. `.chezmoitemplates/rtk-config.toml` *was*
  formatted — it is a plain TOML file with no template actions in it.
- `dot_zshrc` / `dot_zprofile` indentation — see above.
- `private_bin/executable_rtk-allowlist-hook` — it is `#!/usr/bin/env python3`,
  not shell.

## Conflict note re: PR #17

PR #17 (`simshanith/rtk-toggle`) also modifies
`dot_config/mise/conf.d/fresh.toml`. **It has since merged** (`38d6796`), and
this branch is based on a `main` that already contains it, so there is no
conflict. Any *other* in-flight branch touching `fresh.toml` will conflict on
the trailing-comment spacing, since this PR touches ~15 scattered lines there.

## Note on chezmoi

Both new files are dot-prefixed, and chezmoi auto-ignores source entries
beginning with `.` (as documented at the top of `.chezmoiignore`), so neither
`.taplo.toml` nor `.editorconfig` gets deployed to `$HOME`. No `.chezmoiignore`
entry needed.


---

## Update: Markdown now formatted, with oxfmt

The original version of this PR deliberately skipped Markdown. That's now done,
using **oxfmt** rather than prettier.

`oxfmt` delegates `.md` to prettier internally, so the output is near-identical
— verified byte-for-byte on this repo's files. The one divergence favours
oxfmt: prettier escapes `seebi/*` → `seebi/\*` inside a table cell, oxfmt
leaves it alone. It's a single Rust binary and does all 7 files in ~160ms.

Added as `oxfmt = "latest"` (npm:oxfmt) beside the other apheleia formatters;
`prettier` stays for TS/JSON/YAML.

**The diff is large but mechanical**: table re-padding, plus prettier's
`*em*` → `_em_` normalization (no option to disable). Checked rather than
assumed:

- fence, link and heading counts unchanged in all 7 files
- the 111 `<kbd>` tags across the cheatsheets survive exactly (61→61, 50→50)
- **idempotent** — a second pass is a no-op on every file. Worth testing
  explicitly: oxc-project/oxc#20778 reports non-idempotent formatting of
  markdown lists with fenced code blocks. This repo doesn't hit it.

`2026_REFRESH.md` now documents the full formatter set and the two decisions
behind it (`align_entries`, the dual-dialect `.editorconfig`).

### Still worth your call

Both taplo and shfmt normalize the `key = value  # why` two-space comment
convention — taplo to a computed column, shfmt to a single space. That's a
deliberate style of yours being given up in exchange for the checks passing.
