### PR TITLE
feat(rtk): uv-run script shebang for the allowlist gate (+ reconcile fix)

### DIFF
--- a/2026_REFRESH.md
+++ b/2026_REFRESH.md
@@ -168,6 +168,10 @@ The list is short on purpose — `cat` `head` `tail` `ls` `gh` `find` `wc` `du`
 `ps` `vitest` `cargo`, plus `git commit` and `git fetch` — each earning its place
 in `rtk gain`. The whole JS toolchain is deliberately absent.
 
+The gate is a `uv run --script` script (`requires-python = ">=3.11"`), so uv
+owns the interpreter and `tomllib` is always there — no vendored TOML parser
+for old Pythons. `rtk-hook enable` refuses to wire it if uv is off PATH.
+
 **How the toggle sticks.** The choice is a marker file
 (`~/.config/rtk-hook-enabled`), per-machine and uncommitted. `chezmoi apply`
 runs `run_after_20-claude-rtk-hook.sh`, which *reconciles to the marker* rather

--- a/private_bin/executable_rtk-allowlist-hook
+++ b/private_bin/executable_rtk-allowlist-hook
@@ -1,4 +1,8 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script --quiet
+# /// script
+# requires-python = ">=3.11"
+# dependencies = []
+# ///
 """Allowlist gate in front of `rtk hook claude` (Claude Code PreToolUse, Bash).
 
 rtk only offers denylists (`exclude_commands`, `transparent_prefixes`), so every
@@ -18,14 +22,20 @@ we only decide *whether* it gets consulted.
 Fails open everywhere. Any parse error, missing rtk, timeout, or unexpected
 exception prints nothing and exits 0, which Claude Code reads as "no rewrite".
 A hook that breaks must never break the user's command.
+
+Runs via `uv run --script` so the interpreter is guaranteed >= 3.11 (tomllib),
+with uv fetching a managed CPython if the system lacks one. If uv itself is
+missing the shebang fails with exit 127 -- Claude Code surfaces a hook error
+but still runs the command unmodified, so even that path fails open.
+`rtk-hook enable` refuses to wire the hook on a machine without uv.
 """
 
 import json
 import os
-import re
 import shlex
 import subprocess
 import sys
+import tomllib
 
 CONFIG_PATH = os.environ.get(
     "RTK_ALLOWLIST_CONFIG",
@@ -46,49 +56,6 @@ SHELL_METACHARS = ("&&", "||", ";", "|", "`", "$(", ">", "<", "&", "\n")
 
 RTK_TIMEOUT_SECONDS = 10
 
-_ARRAY_RE = re.compile(r"^([A-Za-z0-9_-]+)\s*=\s*\[(.*?)\]", re.DOTALL | re.MULTILINE)
-_SECTION_RE = re.compile(r"^\s*\[([A-Za-z0-9_.-]+)\]\s*$", re.MULTILINE)
-_STRING_RE = re.compile(r'"([^"]*)"')
-
-
-def _parse_toml_subset(text: str) -> dict:
-    """Parse the `key = [...]` / `[section]` subset this config uses.
-
-    Only needed on Python < 3.11, which has no tomllib. Deliberately narrow: it
-    understands string arrays and one level of section, which is the whole
-    schema. Anything richer belongs in tomllib, not here.
-    """
-    # Strip comments, but not a '#' inside a quoted string.
-    lines = []
-    for line in text.splitlines():
-        out, in_string, index = [], False, 0
-        while index < len(line):
-            char = line[index]
-            if char == '"':
-                in_string = not in_string
-            elif char == "#" and not in_string:
-                break
-            out.append(char)
-            index += 1
-        lines.append("".join(out))
-    stripped = "\n".join(lines)
-
-    # Split into (section_name, body) chunks; the pre-header body is top level.
-    chunks, last_end, current = [], 0, None
-    for match in _SECTION_RE.finditer(stripped):
-        chunks.append((current, stripped[last_end:match.start()]))
-        current, last_end = match.group(1), match.end()
-    chunks.append((current, stripped[last_end:]))
-
-    result: dict = {}
-    for section, body in chunks:
-        target = result if section is None else result.setdefault(section, {})
-        if not isinstance(target, dict):
-            continue
-        for match in _ARRAY_RE.finditer(body):
-            target[match.group(1)] = _STRING_RE.findall(match.group(2))
-    return result
-
 
 def load_config(path: str = CONFIG_PATH):
     """Return (allow_set, subcommand_map), falling back to the built-in defaults."""
@@ -98,16 +65,8 @@ def load_config(path: str = CONFIG_PATH):
     except Exception:
         return set(DEFAULT_ALLOW), {k: set(v) for k, v in DEFAULT_SUBCOMMANDS.items()}
 
-    data = None
     try:
-        import tomllib  # Python 3.11+
-
         data = tomllib.loads(raw.decode("utf-8"))
-    except ImportError:
-        try:
-            data = _parse_toml_subset(raw.decode("utf-8"))
-        except Exception:
-            data = None
     except Exception:
         data = None  # malformed TOML -- prefer the safe defaults over a wrong list
 

--- a/private_bin/executable_rtk-hook
+++ b/private_bin/executable_rtk-hook
@@ -36,7 +36,10 @@ ALLOWLIST="${XDG_CONFIG_HOME:-$HOME/.config}/rtk-allowlist.toml"
 GATE="$HOME/bin/rtk-allowlist-hook"
 
 # Must match run_after_20-claude-rtk-hook.sh and the removal matcher below.
-WRAPPER='if [ -x "$HOME/bin/rtk-allowlist-hook" ]; then "$HOME/bin/rtk-allowlist-hook"; fi'
+# The gate's shebang is `uv run --script`, so also require uv here: if it ever
+# leaves PATH the hook skips silently (fail open) instead of erroring 127 on
+# every Bash call. Reconcile rewrites any older wired string to this one.
+WRAPPER='if command -v uv >/dev/null 2>&1 && [ -x "$HOME/bin/rtk-allowlist-hook" ]; then "$HOME/bin/rtk-allowlist-hook"; fi'
 
 usage() {
 	cat <<'EOF'
@@ -108,6 +111,13 @@ do_enable() {
 		exit 1
 	fi
 	need_python || exit 1
+	# The gate's shebang is `uv run --script` (guarantees python >= 3.11 for
+	# tomllib), so a machine without uv would wire a hook that can't run.
+	if ! command -v uv >/dev/null 2>&1; then
+		echo "rtk-hook: uv not on PATH -- the allowlist gate runs via \`uv run\`." >&2
+		echo "          It ships in the mise baseline; try \`mise install uv\`." >&2
+		exit 1
+	fi
 
 	if act && [ ! -f "$MARKER" ]; then
 		mkdir -p "$(dirname "$MARKER")"
@@ -128,7 +138,9 @@ changes = []
 
 # Only ever rewrite an entry that is already rtk's (or already ours). A Bash
 # hook pointing at some other tool belongs to that tool and is left alone.
-RTK_COMMANDS = ("rtk hook claude", wrapper)
+# Substring match, same as disable: exact equality against the current wrapper
+# would treat any older wrapper revision as foreign and wire a duplicate.
+RTK_MARKERS = ("rtk hook claude", "rtk-allowlist-hook")
 
 try:
     with open(settings_path) as fh:
@@ -150,7 +162,9 @@ if bash_entry is None:
     changes.append(f"{verb} Bash PreToolUse hook")
 else:
     inner = bash_entry.setdefault("hooks", [])
-    existing = [h for h in inner if isinstance(h, dict) and h.get("command") in RTK_COMMANDS]
+    existing = [h for h in inner
+                if isinstance(h, dict)
+                and any(m in str(h.get("command", "")) for m in RTK_MARKERS)]
     if not existing:
         inner.append({"type": "command", "command": wrapper})
         changes.append(f"{verb} allowlist hook alongside existing Bash hooks")
@@ -158,7 +172,7 @@ else:
         for hook in existing:
             if hook.get("command") != wrapper:
                 hook["command"] = wrapper
-                changes.append(f"{'would repoint' if dry else 'repointed'} Bash hook off `rtk hook claude`")
+                changes.append(f"{'would repoint' if dry else 'repointed'} Bash hook at the current wrapper")
 
 if changes and not dry:
     if os.path.exists(settings_path):


### PR DESCRIPTION
Follow-up review of #17, per request: manage the gate's Python with uv.

## uv script shebang

`rtk-allowlist-hook` now starts with

    #!/usr/bin/env -S uv run --script --quiet
    # /// script
    # requires-python = ">=3.11"
    # dependencies = []
    # ///

per the [mise cookbook uv-scripts pattern](https://mise.en.dev/mise-cookbook/python.html#uv-scripts). uv owns the interpreter (fetching a managed CPython if needed), so `tomllib` is guaranteed — the ~55-line vendored TOML-subset parser for pre-3.11 Pythons is deleted outright. Net: the script shrinks by a third.

Fail-open is preserved at every layer:
- **uv present** (the normal case — it's in the mise baseline): warm latency ~50 ms per Bash call, cached env, Python 3.14.5 here.
- **uv missing at enable time**: `rtk-hook enable` refuses with a pointer to `mise install uv`, rather than wiring a hook that can't run.
- **uv vanishes later**: the wired wrapper now guards on `command -v uv` and skips silently instead of erroring 127 on every Bash call.

## Reconcile bug found while testing (latent in #17)

`enable` matched already-wired hooks by **exact equality** against the current `WRAPPER` string. Any wrapper revision — like this one — made the old wired string look foreign, so enable added a **duplicate** hook alongside it. Fixed by matching on the same substrings `disable` already uses (`rtk hook claude`, `rtk-allowlist-hook`) and repointing to the current wrapper.

## Verified (sandboxed $HOME, stub rtk)

- allowed / blocked / pipeline / `git commit` vs `git status` / malformed-config-falls-back-to-defaults: all behave identically to before
- old #17 wrapper and raw `rtk hook claude` both **repoint** (count stays 1); foreign sibling hook preserved through enable→disable round-trip; re-enable idempotent
- dry-run proven a byte-for-byte no-op via checksum
- `bash -n` + `shfmt -d` clean; `--quiet` keeps uv's env creation off stderr even on first run

No conflict with #18 expected (different files, bar a 3-line addition to `2026_REFRESH.md`).